### PR TITLE
ci: add semantic PR title validation to enforce conventional commits

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,25 @@
+name: Semantic PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          requireScope: false
+          ignoreLabels: |
+            release-please


### PR DESCRIPTION
Release-please requires conventional commit format to parse commits and determine version bumps. This workflow validates PR titles before merge, preventing non-conventional squash merge messages like "Dev (#19)" from landing on main and silently skipping release PR creation.