### PR TITLE
refactor(metrics): introduce ObservabilityBus and dynamic worker reporting  

### DIFF
--- a/docs/gold-band/dynamic-worker-bus-events.md
+++ b/docs/gold-band/dynamic-worker-bus-events.md
@@ -1,0 +1,304 @@
+# Dynamic Worker Bus 事件上报方案
+
+**状态**: 设计阶段  
+**日期**: 2026-06-17  
+**关联**: 
+- `docs/gold-band/observability-bus-design.md` — ObservabilityBus 架构
+- `docs/gold-band/fix-token-metrics-reporting.md` — Token 上报修复
+
+---
+
+## 1. 背景
+
+ObservabilityBus 重构后，外层 `Worker` 节点的 token 上报已恢复正常。但会话 auto 模式使用 `AiDynamic` 节点，其内部的 dynamic worker（bootstrap、worker、acceptance）不在 Bus 上发事件，导致：
+
+- **AiDynamic 外层节点** `NodeCompleted` 上报的 token 始终为 0（它自己不跑 ACP）
+- **Dynamic worker** 有 token 数据（跑了 ACP）但不上报
+
+本方案让 dynamic worker 也通过 `ObservabilityBus` 发射 `NodeStarted` / `NodeCompleted` 事件。
+
+## 2. 当前 Dynamic Worker 执行流程
+
+```
+drive_from_node_with_initial_session()
+  └─ execute_ai_dynamic_node()
+       └─ drive_dynamic_graph()
+            └─ launch_ready_dynamic_nodes()
+                 └─ thread::spawn {
+                      execute_dynamic_node_job(app, task_id, run_id, round_id, ...)
+                        └─ execute_dynamic_worker(ctx, graph, node)
+                             └─ ctx.app.provider_for_id(...).run_worker_with_callbacks(invocation)
+                                  └─ client::run_prompt()
+                                       └─ write_session() → acp.snapshot.json 写入 token
+                        → 返回 DynamicExecutionResult { node, proposals }
+                        → tx.send(DynamicExecutionMessage { node_id, result })
+                      }
+            └─ rx.recv() → apply_dynamic_execution_message()
+```
+
+关键约束：
+- Dynamic worker 在 `thread::spawn` 的独立线程中运行
+- 结果通过 `mpsc::channel` 传回主图循环
+- `DynamicExecutionContext` 已持有 `app: &App`，其中 `app.observability_bus` 可直接使用
+- `execute_dynamic_node_job` 通过 `app.clone_for_background()` 获得 App 引用，Bus 通过 `Arc` 共享
+
+## 3. 目标架构
+
+```
+execute_dynamic_node_job(app, task_id, run_id, ...)
+  │
+  ├── emit NodeStarted (predecessor=None, status=RUNNING)
+  │
+  ├── execute_dynamic_worker(ctx, graph, node)
+  │     └── provider.run_worker_with_callbacks()
+  │           └── ACP session → acp.snapshot.json
+  │
+  └── emit NodeCompleted (outcome, attempt_dir → subscriber 自读 token)
+```
+
+每个 dynamic worker 独立上报一条 `NodeStarted` + `NodeCompleted` 批次。
+
+## 4. 详细设计
+
+### 4.1 新增：dynamic worker event 构建函数
+
+**文件**: `src/app/orchestrator.rs`
+
+```rust
+/// Emit a NodeStarted event for a dynamic worker.
+fn emit_dynamic_worker_started(
+    app: &App,
+    ctx: &DynamicExecutionContext<'_>,
+    node: &DynamicNodeState,
+) {
+    let attempt_dir = app
+        .paths
+        .dynamic_node_attempt_dir(
+            ctx.task_id, ctx.run_id, ctx.round_id,
+            ctx.outer_node_id, ctx.outer_attempt_id,
+            &node.id, &dynamic_attempt_id(node),
+        )
+        .to_string();
+
+    app.observability_bus.emit(WorkflowEvent::NodeStarted {
+        task_id: ctx.task_id.to_string(),
+        task_uuid: None,           // dynamic workers don't have UUIDs
+        run_id: ctx.run_id.to_string(),
+        run_uuid: None,
+        round_id: ctx.round_id.to_string(),
+        round_uuid: None,
+        node_id: node.id.clone(),
+        node_uuid: None,
+        attempt_id: dynamic_attempt_id(node),
+        repo_root: app.paths.repo_root.to_string(),
+        seq: None,                 // dynamic workers don't have round trace
+        node_name: Some(node.title.clone()),
+        agent_type: node.provider.clone(),
+        started_at: node.started_at.clone().unwrap_or_else(now_rfc3339_like),
+        attempt_dir: Some(attempt_dir),
+        predecessor: None,         // independent workers within dynamic graph
+    });
+}
+
+/// Emit a NodeCompleted event for a dynamic worker.
+fn emit_dynamic_worker_completed(
+    app: &App,
+    ctx: &DynamicExecutionContext<'_>,
+    node: &DynamicNodeState,
+) {
+    let attempt_dir = app
+        .paths
+        .dynamic_node_attempt_dir(
+            ctx.task_id, ctx.run_id, ctx.round_id,
+            ctx.outer_node_id, ctx.outer_attempt_id,
+            &node.id, &dynamic_attempt_id(node),
+        )
+        .to_string();
+
+    let outcome = match node.outcome {
+        Some(NodeOutcome::Success) => "SUCCESS",
+        _ => "FAILED",
+    };
+
+    app.observability_bus.emit(WorkflowEvent::NodeCompleted {
+        task_id: ctx.task_id.to_string(),
+        task_uuid: None,
+        run_id: ctx.run_id.to_string(),
+        run_uuid: None,
+        round_id: ctx.round_id.to_string(),
+        round_uuid: None,
+        node_id: node.id.clone(),
+        node_uuid: None,
+        attempt_id: dynamic_attempt_id(node),
+        repo_root: app.paths.repo_root.to_string(),
+        seq: None,
+        node_name: node.title.clone(),
+        agent_type: node.provider.clone(),
+        started_at: node.started_at.clone().unwrap_or_default(),
+        finished_at: node.finished_at.clone(),
+        outcome: outcome.to_string(),
+        attempt_dir,
+    });
+}
+```
+
+### 4.2 修改：在 execute_dynamic_node_job 中嵌入事件发射
+
+**文件**: `src/app/orchestrator.rs`
+
+```diff
+ fn execute_dynamic_node_job(
+     app: &App,
+     task_id: &str,
+     run_id: &str,
+     round_id: &str,
+     outer_node_id: &str,
+     outer_attempt_id: &str,
+     dynamic: &AiDynamicNode,
+     node: DynamicNodeState,
+ ) -> Result<DynamicExecutionResult> {
+     // … load run/graph, build ctx …
+
++    // ── Observability: notify dynamic worker started ──
++    emit_dynamic_worker_started(app, &ctx, &node);
+
+     match node.kind {
+         DynamicNodeKind::Worker => {
+-            execute_dynamic_worker(&ctx, &graph, node)
++            let result = execute_dynamic_worker(&ctx, &graph, node)?;
++            // ── Observability: notify dynamic worker completed ──
++            emit_dynamic_worker_completed(app, &ctx, &result.node);
++            Ok(result)
+         }
+         DynamicNodeKind::WorkflowInvocation => {
+-            execute_dynamic_workflow_invocation(&ctx, &graph, node)
++            let result = execute_dynamic_workflow_invocation(&ctx, &graph, node)?;
++            emit_dynamic_worker_completed(app, &ctx, &result.node);
++            Ok(result)
+         }
+         DynamicNodeKind::Merge | DynamicNodeKind::Acceptance => {
+-            execute_dynamic_agent_stage(&ctx, &graph, node)
++            let result = execute_dynamic_agent_stage(&ctx, &graph, node)?;
++            emit_dynamic_worker_completed(app, &ctx, &result.node);
++            Ok(result)
+         }
+     }
+ }
+```
+
+**关键点**：
+- `NodeStarted` 在 worker 开始前发射（无论类型）
+- `NodeCompleted` 在 worker 完成后发射（无论成功/失败）
+- 失败路径：如果 `execute_dynamic_worker` 返回 `Err`，`emit_dynamic_worker_completed` 不会被调用。这是正确的——失败的 worker 不应该报告为 COMPLETED。可以在错误路径中单独发射一个 FAILED 事件，但当前版本跳过（失败的 worker 会通过 `pause` 路径重试）
+
+### 4.3 处理错误路径
+
+如果 worker 执行失败（`execute_dynamic_worker` 返回 `Err`），我们应该报告 FAILED 事件以保持一致性：
+
+```rust
+match node.kind {
+    DynamicNodeKind::Worker => {
+        match execute_dynamic_worker(&ctx, &graph, node) {
+            Ok(result) => {
+                emit_dynamic_worker_completed(app, &ctx, &result.node);
+                Ok(result)
+            }
+            Err(e) => {
+                // Emit FAILED event — node didn't complete but we still record it
+                let failed_node = DynamicNodeState {
+                    outcome: Some(NodeOutcome::Failure),
+                    finished_at: Some(now_rfc3339_like()),
+                    ..node.clone()
+                };
+                emit_dynamic_worker_completed(app, &ctx, &failed_node);
+                Err(e)
+            }
+        }
+    }
+    // … same pattern for other kinds …
+}
+```
+
+### 4.4 调用方无需修改
+
+`ObservabilityBus` 已通过 `App` 传递到 `execute_dynamic_node_job`。无需修改调用链签名。
+
+### 4.5 Settings check 在 subscriber 中
+
+`create_metrics_subscriber` 已有统一的 settings guard（enabled → endpoint → api_key）。Dynamic worker 的 events 也会经过同样的 check——如果指标被禁用，event 到达 subscriber 后立即 return，零开销。
+
+## 5. 数据流总览
+
+```
+drive_from_node_with_initial_session (AiDynamic outer node)
+  ├── emit NodeStarted (outer)
+  │     predecessor = previous node's LastExecutedNode
+  │     attempt_dir = outer node's attempt dir (no ACP data)
+  │
+  ├── execute_ai_dynamic_node()
+  │     │
+  │     ├── dynamic_worker_1 (bootstrap)
+  │     │     ├── emit NodeStarted (inner) ← NEW
+  │     │     ├── execute_dynamic_worker → ACP session → acp.snapshot.json
+  │     │     └── emit NodeCompleted (inner) ← NEW
+  │     │           attempt_dir = dynamic_node_attempt_dir(..., "bootstrap", "attempt-001")
+  │     │           subscriber → read_session_tokens() → real tokens!
+  │     │
+  │     ├── dynamic_worker_2
+  │     │     ├── emit NodeStarted (inner) ← NEW
+  │     │     ├── execute_dynamic_worker → ACP session → acp.snapshot.json
+  │     │     └── emit NodeCompleted (inner) ← NEW
+  │     │
+  │     └── dynamic_worker_N (acceptance)
+  │           └── ...
+  │
+  └── emit NodeCompleted (outer)
+        attempt_dir = outer node's attempt dir (no ACP data → token=0, correct)
+```
+
+### 指标上报效果
+
+**修复前**（当前）：
+```
+batch[0] = AiDynamic 外层节点 started (token=0, RUNNING)
+batch[1] = AiDynamic 外层节点 completed (token=0, SUCCESS)  ← 假数据
+```
+
+**修复后**：
+```
+batch[0] = AiDynamic 外层节点 started    (token=0, RUNNING)
+batch[1] = AiDynamic bootstrap started    (token=0, RUNNING)      ← NEW
+batch[2] = AiDynamic bootstrap completed  (token=39781, SUCCESS)  ← NEW, 真实 token
+batch[3] = AiDynamic worker-1 started     (token=0, RUNNING)      ← NEW
+batch[4] = AiDynamic worker-1 completed   (token=12653, SUCCESS)  ← NEW, 真实 token
+batch[5] = AiDynamic acceptance started   (token=0, RUNNING)      ← NEW
+batch[6] = AiDynamic acceptance completed (token=5192,  SUCCESS)  ← NEW, 真实 token
+batch[7] = AiDynamic 外层节点 completed   (token=0, SUCCESS)
+```
+
+## 6. 文件变更清单
+
+| 文件 | 操作 | 行数 |
+|---|---|---|
+| `src/app/orchestrator.rs` | 新增 `emit_dynamic_worker_started` / `emit_dynamic_worker_completed` 两个函数 + 修改 `execute_dynamic_node_job` | +80 |
+| **总计** | | **+80** |
+
+仅一个文件！不需要改任何调用方或数据结构。
+
+## 7. 风险评估
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| Dynamic worker 产生大量事件 | **低** | 每个 AiDynamic graph 只有 3-10 个 worker，事件量与人工 workflow 的节点数相当 |
+| `NodeStarted`/`NodeCompleted` 成对不匹配（错误路径漏发） | **中** | 在 `Err` 路径中也发射 FAILED 事件（见 4.3）。worker 重试会重新发 NodeStarted |
+| `attempt_dir` 路径构建错误 | **低** | 使用已有的 `dynamic_node_attempt_dir` 函数（已验证可用），`read_session_tokens` 通过 `.parent().join("acp.snapshot.json")` 解析 |
+| `dynamic_attempt_id` 硬编码 "attempt-001" | **低** | 当前只有一次尝试；如果未来支持重试，`dynamic_attempt_id` 会更新，emit 自动跟随 |
+| Bus 跨线程 emit（dynamic worker 在 `thread::spawn` 中） | **极低** | `ObservabilityBus` 是 `Send + Sync`，`emit()` 使用 `RwLock::read()` |
+
+## 8. 验证方法
+
+1. 编译通过：`cargo check --manifest-path src-tauri/Cargo.toml`
+2. 从会话页面发起一个 auto 模式任务
+3. 检查指标日志 `[node-metrics]` 中是否有 dynamic worker 的 `NodeStarted` / `NodeCompleted` 事件
+4. 检查 `NodeCompleted` 事件的 `inputTokens`/`outputTokens`/`totalTokens` 是否为非 0
+5. 对比 dynamic worker 的 `acp.snapshot.json` 中的值与上报值

--- a/docs/gold-band/observability-bus-design.md
+++ b/docs/gold-band/observability-bus-design.md
@@ -1,0 +1,758 @@
+# Gold-Band ObservabilityBus 技术方案
+
+**状态**: 设计阶段  
+**日期**: 2026-06-17  
+**关联**: `docs/gold-band/fix-token-metrics-reporting.md`
+
+---
+
+## 1. 动机
+
+当前 metrics 上报的实现存在以下问题：
+
+| 问题 | 影响 |
+|---|---|
+| orchestrator 中嵌入了 ~50 行 `MetricsEventContext` 构造代码（重复两次） | 主循环可读性下降 |
+| orchestrator 需要手动调用 `read_session_tokens()` 读取 token 文件 | 编排层关心了不该关心的关注点 |
+| `LastExecutedNode` 携带 `input_tokens`/`output_tokens`/`cache_read_tokens`/`total_tokens` | 领域泄漏 — token 是 metrics 概念，不应出现在运行时持久化数据模型里 |
+| `MetricsEvent` + `MetricsEventContext` 两套重叠的结构体 | 概念重复 |
+| 新增观察者（如 tracing、audit log）需修改 orchestrator | 违反开闭原则 |
+| `app.metrics_callback` 是单订阅者设计 | 扩展性受限 |
+
+## 2. 目标架构
+
+引入 `ObservabilityBus` 作为轻量事件总线，orchestrator 只发布通用 `WorkflowEvent`，metrics 等观察者以订阅者身份独立消费事件。
+
+```
+                        ┌─────────────────────────────────────┐
+                        │          ObservabilityBus            │
+                        │   subscribers: RwLock<Vec<Sub>>      │
+                        │                                      │
+                        │   subscribe(handler)                 │
+                        │   emit(event) → for each sub:         │
+                        │     catch_unwind(handler(event))     │
+                        └──────────────┬──────────────────────┘
+                                       │ emit(WorkflowEvent)
+              ┌────────────────────────┼────────────────────────┐
+              ▼                        ▼                        ▼
+   ┌──────────────────┐   ┌──────────────────┐   ┌──────────────────┐
+   │  MetricsReporter │   │  TraceLogger     │   │  AuditLogger     │
+   │  (subscribe)     │   │  (未来扩展)       │   │  (未来扩展)       │
+   │                  │   │                  │   │                  │
+   │  读取 token      │   │                  │   │                  │
+   │  构建 HTTP 请求  │   │                  │   │                  │
+   └──────────────────┘   └──────────────────┘   └──────────────────┘
+
+        orchestrator 不感知任何订阅者，只 emit 事件
+```
+
+## 3. 详细设计
+
+### 3.1 新增：`ObservabilityBus`
+
+**文件**: `src/app/observability.rs`（新文件）
+
+```rust
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::{Arc, RwLock};
+
+use crate::app::WorkflowEvent;
+
+/// Lightweight in-process event bus for workflow lifecycle events.
+///
+/// Subscribers register via [`subscribe`] (typically during app setup, before
+/// any workflow starts). The orchestrator publishes via [`emit`]. Each
+/// subscriber is invoked inside `catch_unwind` — a panic in one subscriber
+/// never affects other subscribers or the orchestrator.
+///
+/// # Constraints
+///
+/// - `subscribe()` acquires a write lock. Only call it during setup, not from
+///   hot paths or inside a subscriber handler.
+/// - Subscriber handlers **must not** call `subscribe()` or `emit()` on the
+///   same `ObservabilityBus` instance — the read lock held by `emit()` would
+///   deadlock with the write lock needed by `subscribe()`.
+///
+/// # Thread safety
+///
+/// `ObservabilityBus` is `Send + Sync`. `emit()` takes a read lock — multiple
+/// threads can emit concurrently without blocking each other.
+#[derive(Clone, Default)]
+pub struct ObservabilityBus {
+    subscribers: Arc<RwLock<Vec<Arc<dyn Fn(WorkflowEvent) + Send + Sync>>>>,
+}
+
+impl ObservabilityBus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a subscriber. Takes a write lock — call during app init,
+    /// not during workflow execution.
+    pub fn subscribe(&self, handler: Arc<dyn Fn(WorkflowEvent) + Send + Sync>) {
+        self.subscribers
+            .write()
+            .expect("ObservabilityBus subscriber list poisoned; this is a bug")
+            .push(handler);
+    }
+
+    /// Publish an event to all subscribers. Each subscriber is wrapped in
+    /// `catch_unwind`. Takes a read lock for the duration of the call.
+    ///
+    /// The event is cloned once per subscriber. With the current single
+    /// subscriber (metrics), this is one clone per emit — negligible. If
+    /// subscriber count grows beyond ~10, consider switching the handler
+    /// signature to `Fn(Arc<WorkflowEvent>)` to avoid per-subscriber clones.
+    pub fn emit(&self, event: WorkflowEvent) {
+        let subs = self
+            .subscribers
+            .read()
+            .expect("ObservabilityBus subscriber list poisoned; this is a bug");
+        for sub in subs.iter() {
+            let sub = Arc::clone(sub);
+            let event = event.clone();
+            let _ = panic::catch_unwind(AssertUnwindSafe(move || {
+                sub(event);
+            }));
+        }
+    }
+}
+```
+
+**关键设计决策**：
+
+1. **`RwLock` 而非 channel** — channel 需要后台任务消费，增加复杂度。`RwLock` + 同步调用足够：订阅者内部自行异步化（`tauri::async_runtime::spawn`），`emit()` 立即返回。
+
+2. **同步 emit，订阅者异步化** — metrics subscriber 内部通过 `tauri::async_runtime::spawn` 发送 HTTP 请求，不阻塞 emit 循环。
+
+3. **框架统一 `catch_unwind`** — 消除 orchestrator 中 3 处手工包装，容错逻辑收敛到一处。
+
+4. **cheap clone** — `ObservabilityBus` 内部是 `Arc`，clone 仅增加引用计数。
+
+### 3.2 新增：`WorkflowEvent` 枚举
+
+**文件**: `src/app/mod.rs`（替代现有 `MetricsEvent` + `MetricsEventContext`）
+
+```rust
+/// Workflow lifecycle events emitted by the orchestrator.
+/// Subscribers (metrics, tracing, audit, etc.) observe these events
+/// without the orchestrator knowing who is listening.
+///
+/// Each event is self-contained — it carries all IDs, metadata, and
+/// filesystem paths a subscriber needs, so no separate "context" struct
+/// is required.
+///
+/// Token counts (input/output/cache/total) are NOT included. Subscribers
+/// read token data themselves from `attempt_dir/acp.snapshot.json` via
+/// `read_session_tokens()`.
+#[derive(Debug, Clone)]
+pub enum WorkflowEvent {
+    /// A node has started executing. The orchestrator is about to invoke
+    /// the AI provider. `predecessor` carries the previous node's snapshot
+    /// so subscribers can close out prior records.
+    NodeStarted {
+        // ── IDs (display + UUID) ──
+        task_id: String,
+        task_uuid: Option<String>,
+        run_id: String,
+        run_uuid: Option<String>,
+        round_id: String,
+        round_uuid: Option<String>,
+        node_id: String,
+        node_uuid: Option<String>,
+        attempt_id: String,
+        // ── Metadata ──
+        repo_root: String,
+        seq: Option<u32>,
+        node_name: Option<String>,
+        agent_type: Option<String>,
+        started_at: String,
+        /// Path to the current node's attempt directory. `None` here
+        /// because the attempt dir hasn't been populated yet (node
+        /// just started). `NodeCompleted` carries the real path.
+        attempt_dir: Option<String>,
+        /// The immediately preceding node in this run.
+        /// `None` for the first node of a run.
+        predecessor: Option<crate::runtime::LastExecutedNode>,
+    },
+
+    /// A node has completed execution (the AI provider returned).
+    /// The orchestrator has already persisted runtime state.
+    NodeCompleted {
+        // ── IDs (display + UUID) ──
+        task_id: String,
+        task_uuid: Option<String>,
+        run_id: String,
+        run_uuid: Option<String>,
+        round_id: String,
+        round_uuid: Option<String>,
+        node_id: String,
+        node_uuid: Option<String>,
+        attempt_id: String,
+        // ── Metadata ──
+        repo_root: String,
+        seq: Option<u32>,
+        node_name: String,
+        agent_type: Option<String>,
+        started_at: String,
+        finished_at: Option<String>,
+        outcome: String, // "SUCCESS" | "FAILED"
+        /// Path to this node's attempt directory. Contains
+        /// `acp.snapshot.json` with final token counts.
+        attempt_dir: String,
+    },
+}
+```
+
+**关键设计决策**：
+
+1. **事件自包含** — 不再需要 `MetricsEventContext`。全部信息在 `WorkflowEvent` 中。
+
+2. **Token 不在此** — 订阅者通过 `attempt_dir` 调用 `read_session_tokens()` 自行读取。
+
+3. **直接用 `LastExecutedNode` 做 predecessor** — 不引入单独的 `PredecessorNode` 结构体。`LastExecutedNode` 去掉 token 字段后本身就是纯粹的 predecessor 描述。两个几乎相同的结构体维护成本高于解耦收益。
+
+### 3.3 修改：`LastExecutedNode`
+
+**文件**: `src/runtime/mod.rs`
+
+```diff
+ #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+ #[serde(rename_all = "camelCase")]
+ pub struct LastExecutedNode {
+     pub node_id: String,
+     pub uuid: String,
+     #[serde(default)]
+     pub round_uuid: String,
+     pub node_name: String,
+     #[serde(default)]
+     pub seq: Option<u32>,
+     #[serde(default)]
+     pub agent_type: Option<String>,
+     pub status: String,
+     pub started_at: String,
+     pub finished_at: Option<String>,
+-    pub input_tokens: u64,
+-    pub output_tokens: u64,
+-    pub cache_read_tokens: u64,
+-    pub total_tokens: u64,
++    /// Path to this node's attempt directory. Subscribers read
++    /// `acp.snapshot.json` from here for token counts.
++    #[serde(default)]
++    pub attempt_dir: Option<String>,
+ }
+```
+
+**变更**：4 个 `u64` token 字段 → 1 个 `Option<String>` attempt_dir。
+
+**持久化兼容性**：
+- 旧 `run.json` → 新代码：`input_tokens`/`output_tokens` 等未知字段被 serde 默认忽略；`attempt_dir` 为 `None`。**兼容。**
+- 新 `run.json` → 旧代码：`attempt_dir` 被忽略；`input_tokens` 等字段缺失，`u64` 默认 0。token 数据丢失但运行正常。**可降级。**
+
+### 3.4 修改：`App` 结构体
+
+**文件**: `src/app/mod.rs`
+
+```diff
+ pub struct App {
+     pub paths: GoldBandPaths,
+     pub config: RuntimeConfig,
+     provider_override: Option<Arc<dyn ProviderAdapter>>,
+     acp_live_update: Option<…>,
+     acp_session_update: Option<…>,
+-    metrics_callback: Option<Arc<dyn Fn(MetricsEventContext, MetricsEvent) + Send + Sync>>,
++    pub observability_bus: ObservabilityBus,
+ }
+```
+
+**变更**：
+- 删除 `metrics_callback`
+- 新增 `observability_bus: ObservabilityBus`（内部 `Arc`，cheap clone）
+- 删除 `with_metrics_callback()` 方法
+- `clone_for_background()` 改为 `observability_bus: self.observability_bus.clone()`
+- `with_config()` / `with_provider_config()` 改为 `observability_bus: ObservabilityBus::new()`
+
+### 3.5 修改：`completed_node_snapshot`
+
+**文件**: `src/app/orchestrator.rs`
+
+```diff
+ fn completed_node_snapshot(
+     round: &RoundState,
+     node: &NodeState,
+-    input_tokens: u64,
+-    output_tokens: u64,
+-    cache_read_tokens: u64,
+-    total_tokens: u64,
++    attempt_dir: Option<String>,
+ ) -> crate::runtime::LastExecutedNode {
+     let status = match node.outcome {
+         Some(NodeOutcome::Success) => "SUCCESS",
+         _ => "FAILED",
+     };
+     let node_name = /* … 不变 … */;
+     let seq = /* … 不变 … */;
+     let agent_type = /* … 不变 … */;
+
+     crate::runtime::LastExecutedNode {
+         node_id: node.node_id.clone(),
+         uuid: node.uuid.clone().unwrap_or_default(),
+         round_uuid: round.uuid.clone().unwrap_or_default(),
+         node_name,
+         seq,
+         agent_type,
+         status: status.to_string(),
+         started_at: node.started_at.clone(),
+         finished_at: node.finished_at.clone(),
+-        input_tokens,
+-        output_tokens,
+-        cache_read_tokens,
+-        total_tokens,
++        attempt_dir,
+     }
+ }
+```
+
+### 3.6 修改：orchestrator 主循环
+
+**文件**: `src/app/orchestrator.rs` — `drive_from_node_with_initial_session`
+
+#### 改动 A：NodeStarted 位置（替代 ~6286-6337 行）
+
+删除 ~50 行 `MetricsEventContext` 构造 + `catch_unwind(callback)`，替换为：
+
+```rust
+// ── Observability: notify node started ──
+app.observability_bus.emit(WorkflowEvent::NodeStarted {
+    task_id: task_id.to_string(),
+    task_uuid: run.task_uuid.clone(),
+    run_id: run.id.clone(),
+    run_uuid: run.uuid.clone(),
+    round_id: round.id.clone(),
+    round_uuid: round.uuid.clone(),
+    node_id: node.node_id.clone(),
+    node_uuid: node.uuid.clone(),
+    attempt_id: node.attempt_id.clone(),
+    repo_root: app.paths.repo_root.to_string(),
+    seq: round.trace.iter()
+        .filter(|t| t.node_id == node.node_id)
+        .map(|t| t.sequence).last(),
+    node_name: node.resolved_config.get("profileName")
+        .and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+        .or_else(|| node.resolved_config.get("profile").and_then(|v| v.as_str()))
+        .map(|s| s.to_string()),
+    agent_type: node.resolved_config.get("provider")
+        .and_then(|v| v.as_str()).map(|s| s.to_string()),
+    started_at: node.started_at.clone(),
+    attempt_dir: None, // current node hasn't executed yet
+    predecessor: run.last_executed_node.clone(),
+});
+```
+
+**对比现状**：
+- 删除了 `MetricsEventContext`（28 行的 struct literal）
+- 删除了 `catch_unwind(AssertUnwindSafe(|| metrics_cb(...)))`（4 行）
+- 删除了 `if let Some(metrics_cb) = &app.metrics_callback { ... }` 条件（2 行）
+- 替换为直接的 `app.observability_bus.emit(...)`（1 行 + struct 字段）
+
+#### 改动 B：NodeCompleted 构建位置（替代 ~6660-6678 行）
+
+删除 `read_session_tokens` + `catch_unwind` + 重复的 `session_paths` 构建，改为仅构建路径：
+
+```rust
+persist_runtime_state(app, task_id, run, round, &node)?;
+
+// Build attempt_dir for both snapshot persistence and observability event
+let attempt_dir = app.paths
+    .attempt_dir(task_id, &run.id, &round.id, &node.node_id, &node.attempt_id)
+    .to_string();
+
+let completed_snapshot = completed_node_snapshot(round, &node, Some(attempt_dir.clone()));
+let decision = decide_next_step(workflow, run, round, &node);
+
+if let Some(next) = apply_control_decision(/* ... */)? {
+    run.last_executed_node = Some(completed_snapshot);
+    // … continue loop …
+}
+```
+
+**关键变化**：不再调用 `read_session_tokens()`。orchestrator 完全脱离 token 文件读取。
+
+#### 改动 C：NodeCompleted 事件（替代 ~6701-6736 行）
+
+删除第二段 `MetricsEventContext` 构造 + `catch_unwind(callback)`，替换为：
+
+```rust
+// Workflow ended — emit completed event for observability subscribers
+run.last_executed_node = Some(completed_snapshot.clone());
+app.observability_bus.emit(WorkflowEvent::NodeCompleted {
+    task_id: task_id.to_string(),
+    task_uuid: run.task_uuid.clone(),
+    run_id: run.id.clone(),
+    run_uuid: run.uuid.clone(),
+    round_id: round.id.clone(),
+    round_uuid: round.uuid.clone(),
+    node_id: node.node_id.clone(),
+    node_uuid: node.uuid.clone(),
+    attempt_id: node.attempt_id.clone(),
+    repo_root: app.paths.repo_root.to_string(),
+    seq: completed_snapshot.seq,
+    node_name: completed_snapshot.node_name.clone(),
+    agent_type: completed_snapshot.agent_type.clone(),
+    started_at: node.started_at.clone(),
+    finished_at: node.finished_at.clone(),
+    outcome: completed_snapshot.status.clone(),
+    attempt_dir, // owned String from above, no clone needed
+});
+```
+
+### 3.7 修改：Metrics 订阅者
+
+**文件**: `src-tauri/src/metrics.rs`
+
+删除整个 `create_metrics_callback` 函数（第 371-610 行），新增 `create_metrics_subscriber`：
+
+```rust
+use gold_band::app::WorkflowEvent;
+use gold_band::acp::events::read_session_tokens;
+
+/// Create a metrics subscriber for the ObservabilityBus.
+/// Replaces the old `create_metrics_callback`.
+///
+/// The subscriber is called **synchronously** by the bus, so it does the
+/// minimum work needed (settings lookup, token read, metric construction)
+/// and then delegates the HTTP request to `tauri::async_runtime::spawn`.
+pub fn create_metrics_subscriber<R: Runtime>(
+    app: AppHandle<R>,
+) -> Arc<dyn Fn(WorkflowEvent) + Send + Sync> {
+    Arc::new(move |event: WorkflowEvent| {
+        // ── Guard: settings check (same as before) ──
+        let settings = match app.try_state::<DesktopState>() {
+            Some(state) => match state.context() {
+                Ok(ctx) => metrics_settings(&ctx.config),
+                Err(_) => return,
+            },
+            None => return,
+        };
+        if !settings.enabled {
+            return;
+        }
+        let node_metrics_endpoint = match &settings.node_metrics_endpoint {
+            Some(ep) => ep.clone(),
+            None => return,
+        };
+        let api_key = match app.try_state::<DesktopState>() {
+            Some(state) => match state.context() {
+                Ok(ctx) => match get_api_key(&ctx.config) {
+                    Some(k) => k,
+                    None => return,
+                },
+                Err(_) => return,
+            },
+            None => return,
+        };
+
+        let user_id = get_system_username();
+        let reported_at = chrono::Local::now()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+
+        match event {
+            WorkflowEvent::NodeStarted {
+                repo_root,
+                task_id,
+                task_uuid,
+                run_id,
+                run_uuid,
+                round_id,
+                round_uuid,
+                node_id,
+                node_uuid,
+                attempt_id,
+                seq,
+                node_name,
+                agent_type,
+                started_at,
+                predecessor,
+                ..
+            } => {
+                let attempt_count = attempt_id
+                    .strip_prefix("attempt-")
+                    .and_then(|n| n.parse::<u32>().ok())
+                    .unwrap_or(0)
+                    .saturating_sub(1);
+
+                let node_status = if attempt_count > 0 {
+                    "Reentrancy".to_string()
+                } else {
+                    "RUNNING".to_string()
+                };
+
+                // ── Build predecessor metric ──
+                let predecessor_item = match &predecessor {
+                    Some(pred) => {
+                        // Read predecessor tokens from ITS attempt_dir
+                        let (input_tokens, output_tokens, cache_read_tokens, total_tokens) =
+                            pred.attempt_dir.as_ref().map(|d| {
+                                // Construct path: <attempt_dir>/acp.session.json
+                                // read_session_tokens uses .parent() to find acp.snapshot.json
+                                let path = std::path::Utf8PathBuf::from(d).join("acp.session.json");
+                                gold_band::acp::events::read_session_tokens(&path)
+                            }).unwrap_or((0, 0, 0, 0));
+
+                        NodeMetricItem {
+                            workspace: repo_root.clone(),
+                            user_id: user_id.clone(),
+                            task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                            run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                            round_id: pred.round_uuid.clone(),
+                            node_id: pred.uuid.clone(),
+                            seq: pred.seq,
+                            node_name: Some(pred.node_name.clone()),
+                            agent_type: pred.agent_type.clone(),
+                            attempt_count: 0,
+                            started_at: Some(to_iso8601(&pred.started_at)),
+                            ended_at: pred.finished_at.as_ref().map(|s| to_iso8601(s)),
+                            input_tokens,
+                            output_tokens,
+                            cache_read_tokens,
+                            total_tokens,
+                            status: pred.status.clone(),
+                            reported_at: Some(reported_at.clone()),
+                        }
+                    }
+                    None => start_sentinel_metric(
+                        &repo_root, &user_id,
+                        &task_uuid.clone().unwrap_or(task_id.clone()),
+                        &run_uuid.clone().unwrap_or(run_id.clone()),
+                        &round_uuid.clone().unwrap_or(round_id.clone()),
+                        &to_iso8601(&started_at),
+                        &reported_at,
+                    ),
+                };
+
+                // ── Build current node metric (token=0 — hasn't executed yet) ──
+                let current = NodeMetricItem {
+                    workspace: repo_root.clone(),
+                    user_id: user_id.clone(),
+                    task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                    run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                    round_id: round_uuid.clone().unwrap_or(round_id.clone()),
+                    node_id: node_uuid.clone().unwrap_or(node_id.clone()),
+                    seq,
+                    node_name: node_name.clone(),
+                    agent_type: agent_type.clone(),
+                    attempt_count,
+                    started_at: Some(to_iso8601(&started_at)),
+                    ended_at: None,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read_tokens: 0,
+                    total_tokens: 0,
+                    status: node_status,
+                    reported_at: Some(reported_at.clone()),
+                };
+
+                let batch = NodeMetricBatch {
+                    metrics: vec![predecessor_item, current],
+                };
+
+                tauri::async_runtime::spawn(async move {
+                    send_node_metrics_batch(&node_metrics_endpoint, &api_key, batch).await;
+                });
+            }
+
+            WorkflowEvent::NodeCompleted {
+                repo_root,
+                task_id,
+                task_uuid,
+                run_id,
+                run_uuid,
+                round_id,
+                round_uuid,
+                node_id,
+                node_uuid,
+                attempt_id: _,
+                seq,
+                node_name,
+                agent_type,
+                started_at,
+                finished_at,
+                outcome,
+                attempt_dir,
+            } => {
+                // Read tokens from this node's attempt_dir
+                let (input_tokens, output_tokens, cache_read_tokens, total_tokens) = {
+                    let path = std::path::Utf8PathBuf::from(&attempt_dir)
+                        .join("acp.session.json");
+                    read_session_tokens(&path)
+                };
+
+                let last_node = NodeMetricItem {
+                    workspace: repo_root.clone(),
+                    user_id: user_id.clone(),
+                    task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                    run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                    round_id: round_uuid.clone().unwrap_or(round_id.clone()),
+                    node_id: node_uuid.clone().unwrap_or(node_id.clone()),
+                    seq,
+                    node_name: Some(node_name.clone()),
+                    agent_type: agent_type.clone(),
+                    attempt_count: 0,
+                    started_at: Some(to_iso8601(&started_at)),
+                    ended_at: finished_at.as_ref().map(|s| to_iso8601(s)),
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    total_tokens,
+                    status: outcome.clone(),
+                    reported_at: Some(reported_at.clone()),
+                };
+
+                // End sentinel: token=0, always
+                let end_sentinel = NodeMetricItem {
+                    workspace: repo_root.clone(),
+                    user_id: user_id.clone(),
+                    task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                    run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                    round_id: round_uuid.clone().unwrap_or(round_id.clone()),
+                    node_id: uuid::Uuid::new_v4().simple().to_string(),
+                    seq: None,
+                    node_name: Some("结束".to_string()),
+                    agent_type: None,
+                    attempt_count: 0,
+                    started_at: finished_at
+                        .as_ref()
+                        .map(|s| to_iso8601(s))
+                        .unwrap_or_else(|| reported_at.clone()),
+                    ended_at: Some(reported_at.clone()),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read_tokens: 0,
+                    total_tokens: 0,
+                    status: outcome,
+                    reported_at: Some(reported_at.clone()),
+                };
+
+                let batch = NodeMetricBatch {
+                    metrics: vec![last_node, end_sentinel],
+                };
+
+                tauri::async_runtime::spawn(async move {
+                    send_node_metrics_batch(&node_metrics_endpoint, &api_key, batch).await;
+                });
+            }
+        }
+    })
+}
+```
+
+**与当前实现的差异**：
+
+| 维度 | 当前 `create_metrics_callback` | 新 `create_metrics_subscriber` |
+|---|---|---|
+| 入参 | `(MetricsEventContext, MetricsEvent)` | `(WorkflowEvent)` — 单一事件，自包含 |
+| Settings guard | 两个 handler 各自检查 | 函数入口统一检查一次 |
+| Token 读取 | `NodeCompleted` 通过 `ctx.acp_session_path`；`NodeStarted` 从 `predecessor.input_tokens`（一直是 0） | 两个分支都通过 `attempt_dir` 读 `read_session_tokens` |
+| HTTP 发送 | `tauri::async_runtime::spawn` | 相同 |
+| 行数 | ~240 行 | ~180 行（含注释） |
+| catch_unwind | `read_tokens_best_effort` 内部 + orchestrator 外部 | bus 框架保证，不再需要 `read_tokens_best_effort`，直接调 `read_session_tokens` |
+
+### 3.8 修改：调用方
+
+**文件**: `src-tauri/src/commands.rs`（3 处）、`commands_conversation.rs`（2 处）、`state.rs`（1 处）
+
+```diff
+-let app = base_app
+-    .with_metrics_callback(crate::metrics::create_metrics_callback(app_handle.clone()));
++let app = base_app;
++app.observability_bus
++    .subscribe(crate::metrics::create_metrics_subscriber(app_handle.clone()));
+```
+
+调用方变化数：6 处，每处 +2/-1 行。
+
+### 3.9 删除项汇总
+
+| 删除项 | 位置 | 说明 |
+|---|---|---|
+| `MetricsEventContext` 结构体 | `src/app/mod.rs:426-454` | 被 `WorkflowEvent` 取代 |
+| `MetricsEvent` 枚举 | `src/app/mod.rs:456-465` | 被 `WorkflowEvent` 取代 |
+| `App.metrics_callback` 字段 | `src/app/mod.rs:477` | 被 `observability_bus` 取代 |
+| `App::with_metrics_callback()` | `src/app/mod.rs:693-698` | 改为 `bus.subscribe()` |
+| `App::clone_for_background()` 中 metrics_callback clone | `src/app/mod.rs:671` | 改为 `self.observability_bus.clone()` |
+| `create_metrics_callback` 函数 | `src-tauri/src/metrics.rs:371-610` | 被 `create_metrics_subscriber` 取代 |
+| orchestrator 中两段 `MetricsEventContext` 构造 | `src/app/orchestrator.rs:6287-6337, 6701-6736` | 替换为 `bus.emit()` |
+| orchestrator 中 `read_session_tokens` + `catch_unwind` | `src/app/orchestrator.rs:6663-6673` | 不必要 |
+| `completed_node_snapshot` 的 4 个 token 参数 | `src/app/orchestrator.rs` | 改为 1 个 `attempt_dir` |
+| `read_tokens_best_effort` 调用 | `src-tauri/src/metrics.rs` | 改为直接调 `read_session_tokens`（bus 已提供 catch_unwind） |
+
+## 4. 文件变更清单
+
+| 文件 | 操作 | 估计行数 |
+|---|---|---|
+| `src/app/observability.rs` | **新增** | +50 |
+| `src/app/mod.rs` | 修改 | +50 / -45 |
+| `src/app/orchestrator.rs` | 修改 | +50 / -75（净 -25） |
+| `src/runtime/mod.rs` | 修改 | +3 / -6 |
+| `src-tauri/src/metrics.rs` | 修改 | +180 / -250（净 -70） |
+| `src-tauri/src/commands.rs` | 修改 | +12 / -6 |
+| `src-tauri/src/commands_conversation.rs` | 修改 | +6 / -3 |
+| `src-tauri/src/state.rs` | 修改 | +3 / -3 |
+| **总计** | | **+354 / -388（净 -34 行）** |
+
+## 5. 迁移步骤
+
+按依赖顺序执行，每步 `cargo check` 编译验证：
+
+| 步骤 | 内容 | 影响范围 | 验证 |
+|---|---|---|---|
+| 1 | 新建 `src/app/observability.rs` | 无依赖 | `cargo check` |
+| 2 | `src/app/mod.rs`：定义 `WorkflowEvent`；`App` 用 `observability_bus` 替换 `metrics_callback`；删除 `MetricsEvent`/`MetricsEventContext` | 步骤 1 | `cargo check`（此时 metrics.rs 引用旧类型会报错，预期行为） |
+| 3 | `src/runtime/mod.rs`：`LastExecutedNode` token → `attempt_dir`；`src/app/orchestrator.rs`：`completed_node_snapshot` 参数修改 + orchestrator 用 `bus.emit()` 替换旧回调 | 步骤 2 | `cargo check` |
+| 4 | `src-tauri/src/metrics.rs`：`create_metrics_subscriber` 替换 `create_metrics_callback` | 步骤 2, 3 | `cargo check` |
+| 5 | `src-tauri/src/commands.rs`、`commands_conversation.rs`、`state.rs`：`subscribe()` 替换 `with_metrics_callback()` | 步骤 4 | `cargo check` |
+| 6 | 端到端验证：执行 workflow，检查 `NodeStarted` predecessor token、`NodeCompleted` last_node token 为非 0 | 全部 | 手动测试 |
+
+## 6. 风险评估
+
+| 风险 | 等级 | 缓解措施 |
+|---|---|---|
+| `LastExecutedNode` 序列化兼容旧 `run.json` | **低** | serde 默认忽略未知字段；`attempt_dir: Option<String>` 有 `#[serde(default)]` → `None` |
+| `RwLock` 死锁（subscriber 内调 subscribe/emit） | **极低** | 文档化约束；当前 subscriber 不调这些方法 |
+| subscriber 丢失 settings guard 导致指标禁用时仍发请求 | **已消除** | subscriber 入口统一检查 settings（见修正 2） |
+| `read_tokens_best_effort` 改为 `read_session_tokens` 后丢失 `catch_unwind` | **已消除** | bus 框架在 emit 循环中统一 `catch_unwind` |
+| 事件 clone 开销 | **低** | 单 subscriber（当前）1 次 clone/emit；工作流级别事件（每节点 1-2 次），非热路径 |
+| 迁移中遗漏某个调用方 | **低** | 步骤 2 删除 `with_metrics_callback` 后，遗漏的调用方立即编译报错 |
+
+## 7. 对工作流执行的影响
+
+**无影响。** 执行模型完全相同：
+
+```
+当前:  orchestrator → catch_unwind → callback(ctx, event)
+                           └→ try_state → enabled? → spawn HTTP
+
+Bus:   orchestrator → bus.emit(event)
+                           └→ RwLock::read()
+                               └→ catch_unwind → subscriber(event)
+                                     └→ try_state → enabled? → spawn HTTP
+```
+
+- 同步调用 → 同步调用（无新增 async 边界）
+- `catch_unwind` 存在 → `catch_unwind` 存在（位置从 orchestrator 移到 bus 框架）
+- `spawn` HTTP → `spawn` HTTP（不变）
+- 额外开销：一次 `RwLock::read()` + 一次闭包间接调用（纳秒级）
+
+## 8. 与当前实现的对比
+
+| 维度 | 当前（token fix 之后） | Bus 模式 |
+|---|---|---|
+| orchestrator 中 metrics 相关代码 | ~50 行 `MetricsEventContext` 构造 | **0 行** |
+| Token 读取位置 | orchestrator（`read_session_tokens` + `catch_unwind`） | **metrics subscriber 内部** |
+| `LastExecutedNode` token 字段 | 4 个 `u64`（领域泄漏） | **0 个**，改为 `attempt_dir: Option<String>` |
+| 容错机制 | 3 处手工 `catch_unwind` | **框架统一保证** |
+| 新增观察者代价 | 修改 `App` 结构体 + orchestrator 主循环 | **`bus.subscribe()` 一行** |
+| 结构体数量 | 5 个 | 2 个（`WorkflowEvent` + `NodeMetricItem`） |
+| 测试性 | callback 耦合 `AppHandle` | subscriber 依赖 `WorkflowEvent` + `AppHandle`（不变） |
+| 净代码量 | — | **-34 行** |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -159,10 +159,12 @@ fn resolve_command_app_with_emitters(
     let (base_app, _) = resolve_workspace_app(context, project_id)?;
     let pid = project_id.map(|s| s.to_string());
     let bg_app = base_app.clone_for_background();
-    Ok(base_app
+    let app = base_app
         .with_acp_live_update(acp_live_update_emitter(app_handle.clone(), pid.clone()))
-        .with_acp_session_update(acp_session_update_emitter(app_handle.clone(), bg_app, pid))
-        .with_metrics_callback(crate::metrics::create_metrics_callback(app_handle.clone())))
+        .with_acp_session_update(acp_session_update_emitter(app_handle.clone(), bg_app, pid));
+    app.observability_bus
+        .subscribe(crate::metrics::create_metrics_subscriber(app_handle.clone()));
+    Ok(app)
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -690,11 +692,12 @@ pub fn start_run(
     task_id: String,
 ) -> CommandResult<RunSummaryVm> {
     let context = state.context().map_err(command_error)?;
-    let app = context.app_with_metrics(
+    let app = context.app_with_acp_live_updates(
         acp_live_update_emitter(app_handle.clone(), None),
         acp_session_update_emitter(app_handle.clone(), context.app(), None),
-        crate::metrics::create_metrics_callback(app_handle),
     );
+    app.observability_bus
+        .subscribe(crate::metrics::create_metrics_subscriber(app_handle.clone()));
     app.run_start_background(&task_id, None)
         .map(run_summary_vm)
         .map_err(command_error)
@@ -814,11 +817,12 @@ pub fn retry_run(
     run_id: String,
 ) -> CommandResult<RunSummaryVm> {
     let context = state.context().map_err(command_error)?;
-    let app = context.app_with_metrics(
+    let app = context.app_with_acp_live_updates(
         acp_live_update_emitter(app_handle.clone(), None),
         acp_session_update_emitter(app_handle.clone(), context.app(), None),
-        crate::metrics::create_metrics_callback(app_handle),
     );
+    app.observability_bus
+        .subscribe(crate::metrics::create_metrics_subscriber(app_handle.clone()));
     app.run_retry(&task_id, &run_id)
         .map(run_summary_vm)
         .map_err(command_error)

--- a/src-tauri/src/commands_conversation.rs
+++ b/src-tauri/src/commands_conversation.rs
@@ -131,8 +131,9 @@ pub async fn create_conversation_run(
             app_handle.clone(),
             app_for_workspace(&context, &workspace_path).map_err(command_error)?,
             Some(project_id_for_emit),
-        ))
-        .with_metrics_callback(crate::metrics::create_metrics_callback(app_handle));
+        ));
+    app.observability_bus
+        .subscribe(crate::metrics::create_metrics_subscriber(app_handle.clone()));
     let run = tauri::async_runtime::spawn_blocking(move || {
         crate::view_models_conversation::create_conversation_run_vm(&app, &input)
             .map_err(command_error)
@@ -171,8 +172,9 @@ pub fn rerun_conversation_task(
             app_handle.clone(),
             app_for_workspace(&context, &workspace_path).map_err(command_error)?,
             Some(project_id.clone()),
-        ))
-        .with_metrics_callback(crate::metrics::create_metrics_callback(app_handle));
+        ));
+    app.observability_bus
+        .subscribe(crate::metrics::create_metrics_subscriber(app_handle.clone()));
     let run =
         crate::view_models_conversation::rerun_conversation_task_vm(&app, &project_id, &task_id)
             .map_err(command_error)?;

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use camino::Utf8PathBuf;
-use gold_band::app::{MetricsEvent, MetricsEventContext};
+use gold_band::app::WorkflowEvent;
 use gold_band::config::RuntimeConfig;
 use serde::Serialize;
 use tauri::{AppHandle, Manager, Runtime};
@@ -72,17 +72,6 @@ fn to_iso8601(ts: &str) -> String {
     } else {
         ts.to_string()
     }
-}
-
-fn read_tokens_best_effort(session_path: Option<String>) -> (u64, u64, u64, u64) {
-    let Some(session_path) = session_path else {
-        return (0, 0, 0, 0);
-    };
-    let session_path = Utf8PathBuf::from(session_path);
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        gold_band::acp::events::read_session_tokens(&session_path)
-    }))
-    .unwrap_or((0, 0, 0, 0))
 }
 
 // ── Settings VM ──────────────────────────────────────────────────────────────
@@ -366,61 +355,79 @@ pub fn start_sentinel_metric(
 
 // ── Orchestrator Callback ────────────────────────────────────────────────────
 
-/// Create a metrics callback that can be passed to `App::with_metrics_callback`.
-/// This bridges the library-crate orchestrator events to the src-tauri metrics module.
-pub fn create_metrics_callback<R: Runtime>(
+/// Create a metrics subscriber for the ObservabilityBus.
+/// Replaces the old `create_metrics_callback`.
+///
+/// The subscriber is called **synchronously** by the bus, so it does the
+/// minimum work needed (settings lookup, token read, metric construction)
+/// and then delegates the HTTP request to `tauri::async_runtime::spawn`.
+pub fn create_metrics_subscriber<R: Runtime>(
     app: AppHandle<R>,
-) -> Arc<dyn Fn(MetricsEventContext, MetricsEvent) + Send + Sync> {
-    Arc::new(move |ctx: MetricsEventContext, event: MetricsEvent| {
+) -> Arc<dyn Fn(WorkflowEvent) + Send + Sync> {
+    Arc::new(move |event: WorkflowEvent| {
+        // ── Guard: settings check (shared by both branches) ──
+        let settings = match app.try_state::<DesktopState>() {
+            Some(state) => match state.context() {
+                Ok(ctx) => metrics_settings(&ctx.config),
+                Err(_) => return,
+            },
+            None => return,
+        };
+        if !settings.enabled {
+            return;
+        }
+        let node_metrics_endpoint = match &settings.node_metrics_endpoint {
+            Some(ep) => ep.clone(),
+            None => return,
+        };
+        let api_key = match app.try_state::<DesktopState>() {
+            Some(state) => match state.context() {
+                Ok(ctx) => match get_api_key(&ctx.config) {
+                    Some(k) => k,
+                    None => return,
+                },
+                Err(_) => return,
+            },
+            None => return,
+        };
+
+        let user_id = get_system_username();
+        let reported_at = chrono::Local::now()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+
         match event {
-            MetricsEvent::NodeStarted { predecessor } => {
+            WorkflowEvent::NodeStarted {
+                repo_root,
+                task_id,
+                task_uuid,
+                run_id,
+                run_uuid,
+                round_id,
+                round_uuid,
+                node_id,
+                node_uuid,
+                attempt_id,
+                seq,
+                node_name,
+                agent_type,
+                started_at,
+                predecessor,
+                ..
+            } => {
                 metrics_log(&format!(
                     "[node-metrics] NodeStarted task={} run={} node={} has_predecessor={}",
-                    ctx.task_id,
-                    ctx.run_id,
-                    ctx.node_id,
+                    task_id,
+                    run_id,
+                    node_id,
                     predecessor.is_some()
                 ));
-                let settings = if let Some(state) = app.try_state::<DesktopState>() {
-                    if let Ok(desktop_ctx) = state.context() {
-                        metrics_settings(&desktop_ctx.config)
-                    } else {
-                        return;
-                    }
-                } else {
-                    return;
-                };
 
-                if !settings.enabled {
-                    return;
-                }
-                let node_metrics_endpoint = match &settings.node_metrics_endpoint {
-                    Some(ep) => ep.clone(),
-                    None => return,
-                };
-                let api_key = if let Some(state) = app.try_state::<DesktopState>() {
-                    if let Ok(desktop_ctx) = state.context() {
-                        match get_api_key(&desktop_ctx.config) {
-                            Some(k) => k,
-                            None => return,
-                        }
-                    } else {
-                        return;
-                    }
-                } else {
-                    return;
-                };
-
-                let user_id = get_system_username();
-                let reported_at = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
-
-                // Determine reentrancy: parse attempt number from attempt_id
-                let attempt_count = ctx
-                    .attempt_id
+                let attempt_count = attempt_id
                     .strip_prefix("attempt-")
                     .and_then(|n| n.parse::<u32>().ok())
                     .unwrap_or(0)
-                    .saturating_sub(1); // attempt-001 → 0, attempt-002 → 1
+                    .saturating_sub(1);
 
                 let node_status = if attempt_count > 0 {
                     "Reentrancy".to_string()
@@ -428,19 +435,65 @@ pub fn create_metrics_callback<R: Runtime>(
                     "RUNNING".to_string()
                 };
 
-                // Build current node metric (use UUIDs for IDs)
+                // ── Build predecessor metric ──
+                let predecessor_item = match &predecessor {
+                    Some(pred) => {
+                        // Read predecessor tokens from ITS attempt_dir
+                        let (input_tokens, output_tokens, cache_read_tokens, total_tokens) =
+                            pred.attempt_dir.as_ref().map(|d| {
+                                let path =
+                                    Utf8PathBuf::from(d).join("acp.session.json");
+                                gold_band::acp::events::read_session_tokens(&path)
+                            }).unwrap_or((0, 0, 0, 0));
+
+                        NodeMetricItem {
+                            workspace: repo_root.clone(),
+                            user_id: user_id.clone(),
+                            task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                            run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                            round_id: pred.round_uuid.clone(),
+                            node_id: pred.uuid.clone(),
+                            seq: pred.seq,
+                            node_name: Some(pred.node_name.clone()),
+                            agent_type: pred.agent_type.clone(),
+                            attempt_count: 0,
+                            started_at: Some(to_iso8601(&pred.started_at)),
+                            ended_at: pred
+                                .finished_at
+                                .as_ref()
+                                .map(|s| to_iso8601(s)),
+                            input_tokens,
+                            output_tokens,
+                            cache_read_tokens,
+                            total_tokens,
+                            status: pred.status.clone(),
+                            reported_at: Some(reported_at.clone()),
+                        }
+                    }
+                    None => start_sentinel_metric(
+                        &repo_root,
+                        &user_id,
+                        &task_uuid.clone().unwrap_or(task_id.clone()),
+                        &run_uuid.clone().unwrap_or(run_id.clone()),
+                        &round_uuid.clone().unwrap_or(round_id.clone()),
+                        &to_iso8601(&started_at),
+                        &reported_at,
+                    ),
+                };
+
+                // ── Build current node metric (token=0 — hasn't executed yet) ──
                 let current = NodeMetricItem {
-                    workspace: ctx.repo_root.clone(),
+                    workspace: repo_root.clone(),
                     user_id: user_id.clone(),
-                    task_id: ctx.task_uuid.clone().unwrap_or(ctx.task_id.clone()),
-                    run_id: ctx.run_uuid.clone().unwrap_or(ctx.run_id.clone()),
-                    round_id: ctx.round_uuid.clone().unwrap_or(ctx.round_id.clone()),
-                    node_id: ctx.node_uuid.clone().unwrap_or(ctx.node_id.clone()),
-                    seq: ctx.seq,
-                    node_name: ctx.node_name.clone(),
-                    agent_type: ctx.agent_type.clone(),
+                    task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                    run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                    round_id: round_uuid.clone().unwrap_or(round_id.clone()),
+                    node_id: node_uuid.clone().unwrap_or(node_id.clone()),
+                    seq,
+                    node_name: node_name.clone(),
+                    agent_type: agent_type.clone(),
                     attempt_count,
-                    started_at: Some(to_iso8601(&ctx.started_at)),
+                    started_at: Some(to_iso8601(&started_at)),
                     ended_at: None,
                     input_tokens: 0,
                     output_tokens: 0,
@@ -448,39 +501,6 @@ pub fn create_metrics_callback<R: Runtime>(
                     total_tokens: 0,
                     status: node_status,
                     reported_at: Some(reported_at.clone()),
-                };
-
-                // Build predecessor metric
-                let predecessor_item = match &predecessor {
-                    Some(pred) => NodeMetricItem {
-                        workspace: ctx.repo_root.clone(),
-                        user_id: user_id.clone(),
-                        task_id: ctx.task_uuid.clone().unwrap_or(ctx.task_id.clone()),
-                        run_id: ctx.run_uuid.clone().unwrap_or(ctx.run_id.clone()),
-                        round_id: pred.round_uuid.clone(),
-                        node_id: pred.uuid.clone(),
-                        seq: pred.seq,
-                        node_name: Some(pred.node_name.clone()),
-                        agent_type: pred.agent_type.clone(),
-                        attempt_count: 0,
-                        started_at: Some(to_iso8601(&pred.started_at)),
-                        ended_at: pred.finished_at.as_ref().map(|s| to_iso8601(s)),
-                        input_tokens: pred.input_tokens,
-                        output_tokens: pred.output_tokens,
-                        cache_read_tokens: pred.cache_read_tokens,
-                        total_tokens: pred.total_tokens,
-                        status: pred.status.clone(),
-                        reported_at: Some(reported_at.clone()),
-                    },
-                    None => start_sentinel_metric(
-                        &ctx.repo_root,
-                        &user_id,
-                        &current.task_id,
-                        &current.run_id,
-                        &current.round_id,
-                        &to_iso8601(&ctx.started_at),
-                        &reported_at,
-                    ),
                 };
 
                 let batch = NodeMetricBatch {
@@ -501,108 +521,99 @@ pub fn create_metrics_callback<R: Runtime>(
                         .map(|m| m.status.as_str())
                         .unwrap_or("?")
                 ));
-                // Fire-and-forget: spawn async task
+
                 let app_handle = app.clone();
                 tauri::async_runtime::spawn(async move {
                     send_node_metrics_batch(&node_metrics_endpoint, &api_key, batch).await;
-                    let _ = app_handle; // keep handle alive
+                    let _ = app_handle;
                 });
             }
-            MetricsEvent::NodeCompleted => {
-                // Workflow ended — send last completed node + end sentinel.
+
+            WorkflowEvent::NodeCompleted {
+                repo_root,
+                task_id,
+                task_uuid,
+                run_id,
+                run_uuid,
+                round_id,
+                round_uuid,
+                node_id,
+                node_uuid,
+                seq,
+                node_name,
+                agent_type,
+                started_at,
+                finished_at,
+                outcome,
+                attempt_dir,
+                suppress_sentinel,
+                ..
+            } => {
                 metrics_log(&format!(
                     "[node-metrics] WorkflowEnded: task={} run={} node={}",
-                    ctx.task_id, ctx.run_id, ctx.node_id
+                    task_id, run_id, node_id
                 ));
-                let settings = if let Some(state) = app.try_state::<DesktopState>() {
-                    if let Ok(desktop_ctx) = state.context() {
-                        metrics_settings(&desktop_ctx.config)
-                    } else {
-                        return;
-                    }
-                } else {
-                    return;
+
+                // Read tokens from this node's attempt_dir
+                let path = Utf8PathBuf::from(&attempt_dir).join("acp.session.json");
+                let (input_tokens, output_tokens, cache_read_tokens, total_tokens) =
+                    gold_band::acp::events::read_session_tokens(&path);
+
+                let last_node = NodeMetricItem {
+                    workspace: repo_root.clone(),
+                    user_id: user_id.clone(),
+                    task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                    run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                    round_id: round_uuid.clone().unwrap_or(round_id.clone()),
+                    node_id: node_uuid.clone().unwrap_or(node_id.clone()),
+                    seq,
+                    node_name: Some(node_name.clone()),
+                    agent_type: agent_type.clone(),
+                    attempt_count: 0,
+                    started_at: Some(to_iso8601(&started_at)),
+                    ended_at: finished_at.as_ref().map(|s| to_iso8601(s)),
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    total_tokens,
+                    status: outcome.clone(),
+                    reported_at: Some(reported_at.clone()),
                 };
 
-                if !settings.enabled {
-                    return;
+                let end_started = finished_at
+                    .as_ref()
+                    .map(|s| to_iso8601(s))
+                    .unwrap_or_else(|| reported_at.clone());
+
+                let end_sentinel = NodeMetricItem {
+                    workspace: repo_root.clone(),
+                    user_id: user_id.clone(),
+                    task_id: task_uuid.clone().unwrap_or(task_id.clone()),
+                    run_id: run_uuid.clone().unwrap_or(run_id.clone()),
+                    round_id: round_uuid.clone().unwrap_or(round_id.clone()),
+                    node_id: uuid::Uuid::new_v4().simple().to_string(),
+                    seq: None,
+                    node_name: Some("结束".to_string()),
+                    agent_type: None,
+                    attempt_count: 0,
+                    started_at: Some(end_started),
+                    ended_at: Some(reported_at.clone()),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read_tokens: 0,
+                    total_tokens: 0,
+                    status: outcome,
+                    reported_at: Some(reported_at.clone()),
+                };
+
+                let mut metrics = vec![last_node];
+                if !suppress_sentinel {
+                    metrics.push(end_sentinel);
                 }
-                let node_metrics_endpoint = match &settings.node_metrics_endpoint {
-                    Some(ep) => ep.clone(),
-                    None => return,
-                };
-                let api_key = if let Some(state) = app.try_state::<DesktopState>() {
-                    if let Ok(desktop_ctx) = state.context() {
-                        match get_api_key(&desktop_ctx.config) {
-                            Some(k) => k,
-                            None => return,
-                        }
-                    } else {
-                        return;
-                    }
-                } else {
-                    return;
-                };
+                let batch = NodeMetricBatch { metrics };
 
                 let app_handle = app.clone();
                 tauri::async_runtime::spawn(async move {
-                    let user_id = get_system_username();
-                    let reported_at = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
-                    let (input_tokens, output_tokens, cache_read_tokens, total_tokens) =
-                        read_tokens_best_effort(ctx.acp_session_path.clone());
-
-                    // Last completed node — use actual outcome from orchestrator
-                    let last_node_status =
-                        ctx.outcome.clone().unwrap_or_else(|| "SUCCESS".to_string());
-                    let last_node = NodeMetricItem {
-                        workspace: ctx.repo_root.clone(),
-                        user_id: user_id.clone(),
-                        task_id: ctx.task_uuid.clone().unwrap_or(ctx.task_id.clone()),
-                        run_id: ctx.run_uuid.clone().unwrap_or(ctx.run_id.clone()),
-                        round_id: ctx.round_uuid.clone().unwrap_or(ctx.round_id.clone()),
-                        node_id: ctx.node_uuid.clone().unwrap_or(ctx.node_id.clone()),
-                        seq: ctx.seq,
-                        node_name: ctx.node_name.clone(),
-                        agent_type: ctx.agent_type.clone(),
-                        attempt_count: 0,
-                        started_at: Some(to_iso8601(&ctx.started_at)),
-                        ended_at: ctx.finished_at.as_ref().map(|s| to_iso8601(s)),
-                        input_tokens,
-                        output_tokens,
-                        cache_read_tokens,
-                        total_tokens,
-                        status: last_node_status.clone(),
-                        reported_at: Some(reported_at.clone()),
-                    };
-                    let end_started = ctx
-                        .finished_at
-                        .as_ref()
-                        .map(|s| to_iso8601(s))
-                        .unwrap_or_else(|| reported_at.clone());
-                    // End sentinel inherits the last node's outcome
-                    let end_sentinel = NodeMetricItem {
-                        workspace: ctx.repo_root.clone(),
-                        user_id: user_id.clone(),
-                        task_id: ctx.task_uuid.clone().unwrap_or(ctx.task_id.clone()),
-                        run_id: ctx.run_uuid.clone().unwrap_or(ctx.run_id.clone()),
-                        round_id: ctx.round_uuid.clone().unwrap_or(ctx.round_id.clone()),
-                        node_id: uuid::Uuid::new_v4().simple().to_string(),
-                        seq: None,
-                        node_name: Some("结束".to_string()),
-                        agent_type: None,
-                        attempt_count: 0,
-                        started_at: Some(end_started),
-                        ended_at: Some(reported_at.clone()),
-                        input_tokens: 0,
-                        output_tokens: 0,
-                        cache_read_tokens: 0,
-                        total_tokens: 0,
-                        status: last_node_status,
-                        reported_at: Some(reported_at.clone()),
-                    };
-                    let batch = NodeMetricBatch {
-                        metrics: vec![last_node, end_sentinel],
-                    };
                     send_node_metrics_batch(&node_metrics_endpoint, &api_key, batch).await;
                     let _ = app_handle;
                 });

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -79,7 +79,7 @@ impl DesktopContext {
             .with_acp_session_update(session_update)
     }
 
-    pub fn app_with_metrics(
+    pub fn app_with_acp_live_updates(
         &self,
         live_update: Arc<
             dyn Fn(
@@ -92,14 +92,10 @@ impl DesktopContext {
         session_update: Arc<
             dyn Fn(gold_band::app::AcpLiveEventContext) -> anyhow::Result<()> + Send + Sync,
         >,
-        metrics_callback: Arc<
-            dyn Fn(gold_band::app::MetricsEventContext, gold_band::app::MetricsEvent) + Send + Sync,
-        >,
     ) -> App {
         self.app()
             .with_acp_live_update(live_update)
             .with_acp_session_update(session_update)
-            .with_metrics_callback(metrics_callback)
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@ mod profiles;
 mod state_access;
 mod state_factory;
 mod transition_context;
+pub mod observability;
 
 use crate::acp::client as acp_client;
 use crate::acp::permission::{cancel_pending_permission_requests, request_cancel};
@@ -424,46 +425,70 @@ pub struct NodeRuntimeSummary {
     pub outgoing_edges: Vec<NodeEdgeSummary>,
 }
 
-/// Context provided to the metrics callback when a node starts or completes execution.
+/// Workflow lifecycle events emitted by the orchestrator via ObservabilityBus.
+/// Subscribers (metrics, tracing, audit, etc.) observe these events without
+/// the orchestrator knowing who is listening.
+///
+/// Each event is self-contained — it carries all IDs, metadata, and
+/// filesystem paths a subscriber needs.
+///
+/// Token counts (input/output/cache/total) are NOT included. Subscribers read
+/// token data themselves from `attempt_dir/acp.snapshot.json`.
 #[derive(Debug, Clone)]
-pub struct MetricsEventContext {
-    pub repo_root: String,
-    // Display IDs
-    pub task_id: String,
-    pub run_id: String,
-    pub round_id: String,
-    pub node_id: String,
-    pub attempt_id: String,
-    // UUIDs (for metrics reporting)
-    pub task_uuid: Option<String>,
-    pub run_uuid: Option<String>,
-    pub round_uuid: Option<String>,
-    pub node_uuid: Option<String>,
-    // Node metadata
-    pub seq: Option<u32>,
-    pub node_name: Option<String>,
-    pub agent_type: Option<String>,
-    pub started_at: String,
-    pub finished_at: Option<String>,
-    pub input_tokens: u64,
-    pub output_tokens: u64,
-    pub cache_read_tokens: u64,
-    pub total_tokens: u64,
-    pub acp_session_path: Option<String>,
-    // Actual outcome of the node (e.g. "SUCCESS", "FAILED").
-    // Used by NodeCompleted to report the real status instead of hardcoding.
-    pub outcome: Option<String>,
-}
-
-/// Event types emitted by the orchestrator for metrics reporting.
-#[derive(Debug, Clone)]
-pub enum MetricsEvent {
-    /// A node has started executing. Includes the predecessor node's last-executed data if available.
+pub enum WorkflowEvent {
+    /// A node has started executing. The orchestrator is about to invoke the
+    /// AI provider. `predecessor` carries the previous node's snapshot.
     NodeStarted {
+        // ── IDs (display + UUID) ──
+        task_id: String,
+        task_uuid: Option<String>,
+        run_id: String,
+        run_uuid: Option<String>,
+        round_id: String,
+        round_uuid: Option<String>,
+        node_id: String,
+        node_uuid: Option<String>,
+        attempt_id: String,
+        // ── Metadata ──
+        repo_root: String,
+        seq: Option<u32>,
+        node_name: Option<String>,
+        agent_type: Option<String>,
+        started_at: String,
+        /// Path to the current node's attempt directory. `None` because the
+        /// node just started — attempt dir hasn't been populated yet.
+        attempt_dir: Option<String>,
+        /// The immediately preceding node in this run (None for first node).
         predecessor: Option<crate::runtime::LastExecutedNode>,
     },
-    /// A node has completed execution. The orchestrator updates `run.last_executed_node`.
-    NodeCompleted,
+    /// A node has completed execution (the AI provider returned). The
+    /// orchestrator has already persisted runtime state.
+    NodeCompleted {
+        // ── IDs (display + UUID) ──
+        task_id: String,
+        task_uuid: Option<String>,
+        run_id: String,
+        run_uuid: Option<String>,
+        round_id: String,
+        round_uuid: Option<String>,
+        node_id: String,
+        node_uuid: Option<String>,
+        attempt_id: String,
+        // ── Metadata ──
+        repo_root: String,
+        seq: Option<u32>,
+        node_name: String,
+        agent_type: Option<String>,
+        started_at: String,
+        finished_at: Option<String>,
+        outcome: String, // "SUCCESS" | "FAILED"
+        /// Path to this node's attempt directory for reading token data.
+        attempt_dir: String,
+        /// When true, the subscriber skips the 「结束」sentinel. Used by
+        /// dynamic workers so that only the outer AiDynamic node produces
+        /// the single begin/end sentinel pair for the whole workflow.
+        suppress_sentinel: bool,
+    },
 }
 
 pub struct App {
@@ -476,7 +501,7 @@ pub struct App {
         >,
     >,
     acp_session_update: Option<Arc<dyn Fn(AcpLiveEventContext) -> Result<()> + Send + Sync>>,
-    metrics_callback: Option<Arc<dyn Fn(MetricsEventContext, MetricsEvent) + Send + Sync>>,
+    pub observability_bus: observability::ObservabilityBus,
 }
 
 #[derive(Debug, Clone)]
@@ -670,7 +695,7 @@ impl App {
             provider_override: self.provider_override.clone(),
             acp_live_update: self.acp_live_update.clone(),
             acp_session_update: self.acp_session_update.clone(),
-            metrics_callback: self.metrics_callback.clone(),
+            observability_bus: self.observability_bus.clone(),
         }
     }
 
@@ -689,14 +714,6 @@ impl App {
         session_update: Arc<dyn Fn(AcpLiveEventContext) -> Result<()> + Send + Sync>,
     ) -> Self {
         self.acp_session_update = Some(session_update);
-        self
-    }
-
-    pub fn with_metrics_callback(
-        mut self,
-        callback: Arc<dyn Fn(MetricsEventContext, MetricsEvent) + Send + Sync>,
-    ) -> Self {
-        self.metrics_callback = Some(callback);
         self
     }
 
@@ -1393,7 +1410,7 @@ impl App {
             provider_override: None,
             acp_live_update: None,
             acp_session_update: None,
-            metrics_callback: None,
+            observability_bus: observability::ObservabilityBus::new(),
         }
     }
 
@@ -1415,7 +1432,7 @@ impl App {
             provider_override: Some(Arc::from(provider)),
             acp_live_update: None,
             acp_session_update: None,
-            metrics_callback: None,
+            observability_bus: observability::ObservabilityBus::new(),
         }
     }
 

--- a/src/app/observability.rs
+++ b/src/app/observability.rs
@@ -1,0 +1,64 @@
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::{Arc, RwLock};
+
+use crate::app::WorkflowEvent;
+
+/// Lightweight in-process event bus for workflow lifecycle events.
+///
+/// Subscribers register via [`subscribe`] (typically during app setup, before
+/// any workflow starts). The orchestrator publishes via [`emit`]. Each
+/// subscriber is invoked inside `catch_unwind` — a panic in one subscriber
+/// never affects other subscribers or the orchestrator.
+///
+/// # Constraints
+///
+/// - `subscribe()` acquires a write lock. Only call it during setup, not from
+///   hot paths or inside a subscriber handler.
+/// - Subscriber handlers **must not** call `subscribe()` or `emit()` on the
+///   same `ObservabilityBus` instance — the read lock held by `emit()` would
+///   deadlock with the write lock needed by `subscribe()`.
+///
+/// # Thread safety
+///
+/// `ObservabilityBus` is `Send + Sync`. `emit()` takes a read lock — multiple
+/// threads can emit concurrently without blocking each other.
+#[derive(Clone, Default)]
+pub struct ObservabilityBus {
+    subscribers: Arc<RwLock<Vec<Arc<dyn Fn(WorkflowEvent) + Send + Sync>>>>,
+}
+
+impl ObservabilityBus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a subscriber. Takes a write lock — call during app init,
+    /// not during workflow execution.
+    pub fn subscribe(&self, handler: Arc<dyn Fn(WorkflowEvent) + Send + Sync>) {
+        self.subscribers
+            .write()
+            .expect("ObservabilityBus subscriber list poisoned; this is a bug")
+            .push(handler);
+    }
+
+    /// Publish an event to all subscribers. Each subscriber is wrapped in
+    /// `catch_unwind`. Takes a read lock for the duration of the call.
+    ///
+    /// The event is cloned once per subscriber. With the current single
+    /// subscriber (metrics), this is one clone per emit — negligible. If
+    /// subscriber count grows beyond ~10, consider switching the handler
+    /// signature to `Fn(Arc<WorkflowEvent>)` to avoid per-subscriber clones.
+    pub fn emit(&self, event: WorkflowEvent) {
+        let subs = self
+            .subscribers
+            .read()
+            .expect("ObservabilityBus subscriber list poisoned; this is a bug");
+        for sub in subs.iter() {
+            let sub = Arc::clone(sub);
+            let event = event.clone();
+            let _ = panic::catch_unwind(AssertUnwindSafe(move || {
+                sub(event);
+            }));
+        }
+    }
+}

--- a/src/app/orchestrator.rs
+++ b/src/app/orchestrator.rs
@@ -6669,10 +6669,11 @@ fn drive_from_node_with_initial_session(
                 .attempt_dir(task_id, &run.id, &round.id, &node.node_id, &node.attempt_id);
         let session_paths = crate::acp::events::AcpAttemptPaths::from_attempt_dir(attempt_dir);
         let (input_tokens, output_tokens, cache_read_tokens, total_tokens) =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                crate::acp::events::read_session_tokens(&session_paths.session)
-            }))
-            .unwrap_or((0, 0, 0, 0));
+
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            crate::acp::events::read_session_tokens(&session_paths.session)
+        }))
+        .unwrap_or((0, 0, 0, 0));
 
         let completed_snapshot = completed_node_snapshot(
             round,

--- a/src/app/orchestrator.rs
+++ b/src/app/orchestrator.rs
@@ -62,7 +62,7 @@ use super::profile_resolver::{resolve_profile_for_node, resolve_workflow_profile
 use super::state_access::{current_attempt_state, load_run_workflow, persist_runtime_state};
 use super::state_factory::create_node_state;
 use super::transition_context::find_latest_worker_ref_for_transition;
-use super::{AcpLiveEventContext, App, is_run_continuable};
+use super::{AcpLiveEventContext, App, WorkflowEvent, is_run_continuable};
 
 struct PreparedRun {
     validated: ValidatedWorkflow,
@@ -1014,10 +1014,7 @@ fn should_pause_for_manual_check(workflow: &ValidatedWorkflow, node: &NodeState)
 fn completed_node_snapshot(
     round: &RoundState,
     node: &NodeState,
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_read_tokens: u64,
-    total_tokens: u64,
+    attempt_dir: Option<String>,
 ) -> crate::runtime::LastExecutedNode {
     let status = match node.outcome {
         Some(crate::domain::NodeOutcome::Success) => "SUCCESS",
@@ -1032,6 +1029,7 @@ fn completed_node_snapshot(
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .or_else(|| node.resolved_config.get("profile").and_then(|v| v.as_str()))
+        .or_else(|| node.resolved_config.get("provider").and_then(|v| v.as_str()))
         .unwrap_or("")
         .to_string();
     let seq = round
@@ -1056,10 +1054,7 @@ fn completed_node_snapshot(
         status: status.to_string(),
         started_at: node.started_at.clone(),
         finished_at: node.finished_at.clone(),
-        input_tokens,
-        output_tokens,
-        cache_read_tokens,
-        total_tokens,
+        attempt_dir,
     }
 }
 
@@ -1433,6 +1428,11 @@ struct DynamicExecutionContext<'a> {
     outer_node_id: &'a str,
     outer_attempt_id: &'a str,
     dynamic: &'a AiDynamicNode,
+    // UUIDs from the outer run/round/node — used for metrics reporting
+    task_uuid: Option<&'a str>,
+    run_uuid: Option<&'a str>,
+    round_uuid: Option<&'a str>,
+    outer_node_uuid: Option<&'a str>,
 }
 
 #[derive(Debug)]
@@ -1902,7 +1902,7 @@ fn dynamic_state_lock_for(
 fn execute_ai_dynamic_node(
     app: &App,
     task_id: &str,
-    run_id: &str,
+    run: &RunState,
     round: &RoundState,
     attempt_id: &str,
     dynamic: &AiDynamicNode,
@@ -1911,11 +1911,15 @@ fn execute_ai_dynamic_node(
     let ctx = DynamicExecutionContext {
         app,
         task_id,
-        run_id,
+        run_id: &run.id,
         round_id: &round.id,
         outer_node_id: &outer_node.node_id,
         outer_attempt_id: attempt_id,
         dynamic,
+        task_uuid: run.task_uuid.as_deref(),
+        run_uuid: run.uuid.as_deref(),
+        round_uuid: round.uuid.as_deref(),
+        outer_node_uuid: outer_node.uuid.as_deref(),
     };
     let mut graph = load_or_create_dynamic_graph(&ctx)?;
     if graph.run.status == DynamicRunStatus::Paused {
@@ -2144,6 +2148,10 @@ fn launch_ready_dynamic_nodes(
         let outer_attempt_id = ctx.outer_attempt_id.to_string();
         let dynamic = ctx.dynamic.clone();
         let tx = tx.clone();
+        let task_uuid = ctx.task_uuid.map(|s| s.to_string());
+        let run_uuid = ctx.run_uuid.map(|s| s.to_string());
+        let round_uuid = ctx.round_uuid.map(|s| s.to_string());
+        let outer_node_uuid = ctx.outer_node_uuid.map(|s| s.to_string());
         thread::spawn(move || {
             let app = background_app;
             let node_id = node_clone.id.clone();
@@ -2157,6 +2165,10 @@ fn launch_ready_dynamic_nodes(
                     &outer_attempt_id,
                     &dynamic,
                     node_clone,
+                    task_uuid.as_deref(),
+                    run_uuid.as_deref(),
+                    round_uuid.as_deref(),
+                    outer_node_uuid.as_deref(),
                 )
             }))
             .unwrap_or_else(|payload| {
@@ -2266,6 +2278,52 @@ fn apply_dynamic_execution_message(
     persist_dynamic_graph(ctx, graph)
 }
 
+fn emit_dynamic_worker_completed(
+    app: &App,
+    ctx: &DynamicExecutionContext<'_>,
+    node: &DynamicNodeState,
+) {
+    let attempt_dir = app
+        .paths
+        .dynamic_node_attempt_dir(
+            ctx.task_id,
+            ctx.run_id,
+            ctx.round_id,
+            ctx.outer_node_id,
+            ctx.outer_attempt_id,
+            &node.id,
+            &dynamic_attempt_id(node),
+        )
+        .to_string();
+
+    let outcome = match node.outcome {
+        Some(NodeOutcome::Success) => "SUCCESS",
+        _ => "FAILED",
+    };
+
+    app.observability_bus
+        .emit(WorkflowEvent::NodeCompleted {
+            task_id: ctx.task_id.to_string(),
+            task_uuid: ctx.task_uuid.map(|s| s.to_string()),
+            run_id: ctx.run_id.to_string(),
+            run_uuid: ctx.run_uuid.map(|s| s.to_string()),
+            round_id: ctx.round_id.to_string(),
+            round_uuid: ctx.round_uuid.map(|s| s.to_string()),
+            node_id: node.id.clone(),
+            node_uuid: None,
+            attempt_id: dynamic_attempt_id(node),
+            repo_root: app.paths.repo_root.to_string(),
+            seq: None,
+            node_name: node.title.clone(),
+            agent_type: node.provider.clone(),
+            started_at: node.started_at.clone().unwrap_or_default(),
+            finished_at: node.finished_at.clone(),
+            outcome: outcome.to_string(),
+            attempt_dir,
+            suppress_sentinel: true,
+        });
+}
+
 fn execute_dynamic_node_job(
     app: &App,
     task_id: &str,
@@ -2275,6 +2333,10 @@ fn execute_dynamic_node_job(
     outer_attempt_id: &str,
     dynamic: &AiDynamicNode,
     node: DynamicNodeState,
+    task_uuid: Option<&str>,
+    run_uuid: Option<&str>,
+    round_uuid: Option<&str>,
+    outer_node_uuid: Option<&str>,
 ) -> Result<DynamicExecutionResult> {
     let dynamic_run_path =
         app.paths
@@ -2298,6 +2360,10 @@ fn execute_dynamic_node_job(
         outer_node_id,
         outer_attempt_id,
         dynamic,
+        task_uuid,
+        run_uuid,
+        round_uuid,
+        outer_node_uuid,
     };
     let index = graph
         .nodes
@@ -2306,7 +2372,8 @@ fn execute_dynamic_node_job(
         .ok_or_else(|| anyhow!("dynamic node `{}` missing from graph", node.id))?;
     graph.run = run;
     graph.nodes[index] = node.clone();
-    match node.kind {
+
+    let result = match node.kind {
         DynamicNodeKind::Worker => execute_dynamic_worker(&ctx, &graph, node),
         DynamicNodeKind::WorkflowInvocation => {
             execute_dynamic_workflow_invocation(&ctx, &graph, node)
@@ -2314,7 +2381,15 @@ fn execute_dynamic_node_job(
         DynamicNodeKind::Merge | DynamicNodeKind::Acceptance => {
             execute_dynamic_agent_stage(&ctx, &graph, node)
         }
+    }?;
+
+    // Only emit NodeCompleted if the worker reached a terminal state
+    // (not Paused — paused workers will be retried and emit fresh events).
+    if result.node.status != DynamicNodeStatus::Paused {
+        emit_dynamic_worker_completed(app, &ctx, &result.node);
     }
+
+    Ok(result)
 }
 
 fn dynamic_node_continue_ref(
@@ -4900,6 +4975,10 @@ pub(crate) fn build_dynamic_prompt_bundle(
         outer_node_id,
         outer_attempt_id,
         dynamic,
+        task_uuid: None,
+        run_uuid: None,
+        round_uuid: None,
+        outer_node_uuid: None,
     };
     let output_contract = match node.kind {
         DynamicNodeKind::Worker | DynamicNodeKind::WorkflowInvocation => {
@@ -6285,8 +6364,8 @@ fn drive_from_node_with_initial_session(
         );
         persist_runtime_state(app, task_id, run, round, &node)?;
 
-        // ── Metrics: notify node started (predecessor + current) ──
-        if let Some(metrics_cb) = &app.metrics_callback {
+        // ── Observability: notify node started ──
+        {
             let seq = round
                 .trace
                 .iter()
@@ -6299,43 +6378,31 @@ fn drive_from_node_with_initial_session(
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
                 .or_else(|| node.resolved_config.get("profile").and_then(|v| v.as_str()))
+                .or_else(|| node.resolved_config.get("provider").and_then(|v| v.as_str()))
                 .map(|s| s.to_string());
             let agent_type = node
                 .resolved_config
                 .get("provider")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            let metrics_ctx = super::MetricsEventContext {
-                repo_root: app.paths.repo_root.to_string(),
+            app.observability_bus.emit(super::WorkflowEvent::NodeStarted {
                 task_id: task_id.to_string(),
-                run_id: run.id.clone(),
-                round_id: round.id.clone(),
-                node_id: node.node_id.clone(),
-                attempt_id: node.attempt_id.clone(),
                 task_uuid: run.task_uuid.clone(),
+                run_id: run.id.clone(),
                 run_uuid: run.uuid.clone(),
+                round_id: round.id.clone(),
                 round_uuid: round.uuid.clone(),
+                node_id: node.node_id.clone(),
                 node_uuid: node.uuid.clone(),
+                attempt_id: node.attempt_id.clone(),
+                repo_root: app.paths.repo_root.to_string(),
                 seq,
                 node_name,
                 agent_type,
                 started_at: node.started_at.clone(),
-                finished_at: node.finished_at.clone(),
-                input_tokens: 0,
-                output_tokens: 0,
-                cache_read_tokens: 0,
-                total_tokens: 0,
-                acp_session_path: None,
-                outcome: None,
-            };
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                metrics_cb(
-                    metrics_ctx,
-                    super::MetricsEvent::NodeStarted {
-                        predecessor: run.last_executed_node.clone(),
-                    },
-                );
-            }));
+                attempt_dir: None,
+                predecessor: run.last_executed_node.clone(),
+            });
         }
 
         let current_node_dsl = workflow
@@ -6363,7 +6430,7 @@ fn drive_from_node_with_initial_session(
             NodeDsl::AiDynamic(dynamic) => execute_ai_dynamic_node(
                 app,
                 task_id,
-                &run.id,
+                run,
                 round,
                 &current_attempt_id,
                 dynamic,
@@ -6662,27 +6729,13 @@ fn drive_from_node_with_initial_session(
         );
         persist_runtime_state(app, task_id, run, round, &node)?;
 
-        // Read real token data from ACP session metadata before building the snapshot.
-        // Wrapped in catch_unwind so a filesystem or parse failure never blocks the workflow.
-        let attempt_dir =
-            app.paths
-                .attempt_dir(task_id, &run.id, &round.id, &node.node_id, &node.attempt_id);
-        let session_paths = crate::acp::events::AcpAttemptPaths::from_attempt_dir(attempt_dir);
-        let (input_tokens, output_tokens, cache_read_tokens, total_tokens) =
+        // Build attempt_dir for both snapshot persistence and observability event.
+        let attempt_dir = app
+            .paths
+            .attempt_dir(task_id, &run.id, &round.id, &node.node_id, &node.attempt_id)
+            .to_string();
 
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            crate::acp::events::read_session_tokens(&session_paths.session)
-        }))
-        .unwrap_or((0, 0, 0, 0));
-
-        let completed_snapshot = completed_node_snapshot(
-            round,
-            &node,
-            input_tokens,
-            output_tokens,
-            cache_read_tokens,
-            total_tokens,
-        );
+        let completed_snapshot = completed_node_snapshot(round, &node, Some(attempt_dir.clone()));
         let decision = decide_next_step(workflow, run, round, &node);
 
         if let Some(next) = apply_control_decision(
@@ -6705,38 +6758,28 @@ fn drive_from_node_with_initial_session(
             invalid_output_repair_prompts = 0;
             continue;
         }
-        // Workflow ended — send final metrics for the last completed node
+        // Workflow ended — emit completed event for observability subscribers
         run.last_executed_node = Some(completed_snapshot.clone());
-        if let Some(metrics_cb) = &app.metrics_callback {
-            // Re-use token data already read above for completed_node_snapshot
-            let metrics_ctx = super::MetricsEventContext {
-                repo_root: app.paths.repo_root.to_string(),
-                task_id: task_id.to_string(),
-                run_id: run.id.clone(),
-                round_id: round.id.clone(),
-                node_id: node.node_id.clone(),
-                attempt_id: node.attempt_id.clone(),
-                task_uuid: run.task_uuid.clone(),
-                run_uuid: run.uuid.clone(),
-                round_uuid: round.uuid.clone(),
-                node_uuid: node.uuid.clone(),
-                seq: completed_snapshot.seq,
-                node_name: Some(completed_snapshot.node_name.clone()),
-                agent_type: completed_snapshot.agent_type.clone(),
-                started_at: node.started_at.clone(),
-                finished_at: node.finished_at.clone(),
-                input_tokens,
-                output_tokens,
-                cache_read_tokens,
-                total_tokens,
-                acp_session_path: Some(session_paths.session.to_string()),
-                outcome: Some(completed_snapshot.status.clone()),
-            };
-            // Send with predecessor = this node's final state
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                metrics_cb(metrics_ctx, super::MetricsEvent::NodeCompleted);
-            }));
-        }
+        app.observability_bus.emit(super::WorkflowEvent::NodeCompleted {
+            task_id: task_id.to_string(),
+            task_uuid: run.task_uuid.clone(),
+            run_id: run.id.clone(),
+            run_uuid: run.uuid.clone(),
+            round_id: round.id.clone(),
+            round_uuid: round.uuid.clone(),
+            node_id: node.node_id.clone(),
+            node_uuid: node.uuid.clone(),
+            attempt_id: node.attempt_id.clone(),
+            repo_root: app.paths.repo_root.to_string(),
+            seq: completed_snapshot.seq,
+            node_name: completed_snapshot.node_name.clone(),
+            agent_type: completed_snapshot.agent_type.clone(),
+            started_at: node.started_at.clone(),
+            finished_at: node.finished_at.clone(),
+            outcome: completed_snapshot.status.clone(),
+            attempt_dir: attempt_dir.clone(),
+            suppress_sentinel: false,
+        });
         return Ok(());
     }
 }

--- a/src/app/state_factory.rs
+++ b/src/app/state_factory.rs
@@ -112,6 +112,16 @@ pub(crate) fn resolved_config_for_node(
             );
         }
         NodeDsl::AiDynamic(dynamic) => {
+            // Extract provider from agent strategy so it's available as a flat key
+            // for metrics (node_name / agent_type fallback).
+            let provider = match &dynamic.agent_strategy {
+                crate::dsl::AiDynamicAgentStrategy::Fixed { provider, .. } => provider.clone(),
+                crate::dsl::AiDynamicAgentStrategy::Dynamic { bootstrap_provider, .. } => bootstrap_provider.clone(),
+            };
+            config.insert(
+                "provider".to_string(),
+                serde_json::Value::String(provider),
+            );
             config.insert(
                 "agentStrategy".to_string(),
                 serde_json::to_value(&dynamic.agent_strategy)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -20,10 +20,10 @@ pub struct LastExecutedNode {
     pub status: String,
     pub started_at: String,
     pub finished_at: Option<String>,
-    pub input_tokens: u64,
-    pub output_tokens: u64,
-    pub cache_read_tokens: u64,
-    pub total_tokens: u64,
+    /// Path to this node's attempt directory. Subscribers read
+    /// `acp.snapshot.json` from here for token counts.
+    #[serde(default)]
+    pub attempt_dir: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

引入 ObservabilityBus 事件总线架构，修复指标上报 token 始终为 0 的问题，并让 AiDynamic 内部 worker 也上报真实 token 数据。

## Background

指标上报的 token 数据（inputTokens / outputTokens / cacheReadTokens / totalTokens）始终为 0。根因是 commit `2135ee9` 在重构时将 `read_session_tokens()` 调用替换成了硬编码 0。

更深层的问题是 metrics callback 与 orchestrator 紧密耦合——orchestrator 需要知道 metrics 的数据结构、字段名、token 文件位置。这违反了关注点分离原则。

## Changes

### 1. 修复 token=0（`870be01`, `6bbd06a`）

恢复 orchestrator 中 `read_session_tokens()` 调用，从 ACP session 文件读取真实 token，替代硬编码 0。外层 `catch_unwind` 保险。

### 2. ObservabilityBus 事件总线（`01e3825`）

| Before | After |
|---|---|
| `App.metrics_callback` 单回调 | `App.observability_bus` 多订阅者总线 |
| `MetricsEventContext`（28 字段）+ `MetricsEvent`（2 变体） | `WorkflowEvent`（2 变体，自包含） |
| orchestrator 手工构建 context + catch_unwind | `bus.emit(event)` 一行，框架统一容错 |
| `LastExecutedNode` 含 4 个 token 字段 | 改为 `attempt_dir` 字符串，token 读取收敛到 subscriber |

### 3. Dynamic worker 上报（`01e3825`）

AiDynamic 内部的 bootstrap / worker / merge / acceptance 节点现在通过 Bus 上报 `NodeCompleted` 事件，携带真实 token 数据。

每个 worker 只报数据，不产生「开始」「结束」sentinel——整个工作流仅外层 AiDynamic 节点产生 1 个开始 + 1 个结束。

### 4. 辅助修复（`01e3825`）

- AiDynamic 节点 `resolved_config` 新增 `provider` 键，修复会话页面 `nodeName` 为空
- Dynamic worker 事件 UUID 与外层一致（不再 display ID / UUID 混用）
- `read_session_tokens` doc comment 修正（`acp.session.json` → `acp.snapshot.json`）

## Files changed

11 files, +1554 / -343

| File | Change |
|---|---|
| `src/app/observability.rs` | **新增** ObservabilityBus（64 行） |
| `src/app/mod.rs` | WorkflowEvent 替代 MetricsEvent/MetricsEventContext；App 结构体 |
| `src/app/orchestrator.rs` | 删除 MetricsEventContext 构造；bus.emit()；dynamic worker 事件 |
| `src/runtime/mod.rs` | LastExecutedNode token 字段 → attempt_dir |
| `src/app/state_factory.rs` | AiDynamic resolved_config 新增 provider |
| `src-tauri/src/metrics.rs` | create_metrics_subscriber 替代 create_metrics_callback |
| `src-tauri/src/commands.rs` | subscribe() 替代 with_metrics_callback() |
| `src-tauri/src/commands_conversation.rs` | 同上 |
| `src-tauri/src/state.rs` | app_with_acp_live_updates 替代 app_with_metrics |
| `docs/gold-band/observability-bus-design.md` | **新增** 架构设计文档 |
| `docs/gold-band/dynamic-worker-bus-events.md` | **新增** Dynamic worker 方案文档 |

## Verification

- `cargo check` library + desktop crate 0 errors
- 指标上报日志确认：NodeStarted predecessor token 非 0，NodeCompleted last_node token 非 0
- Dynamic worker（bootstrap）上报验证：input=48209, output=3473, cacheRead=41088, total=92770
- UUID 一致性：外层节点与 dynamic worker 使用相同 taskId/runId/roundId UUID