### PR TITLE
feat(mcp): add SSE transport, managed servers, builtin injection, and…

### DIFF
--- a/configs/channels/wb.json
+++ b/configs/channels/wb.json
@@ -21,7 +21,7 @@
     {
       "id": "maling-code-graph",
       "name": "码灵代码图谱",
-      "helpMessage": "码灵代码图谱提供代码搜索、调用链分析、节点详情等能力。\n\n接入方式：\n1. 在码灵代码图谱控制台(地址：http://maling.weoa.com/)接入项目\n2. 在 Agent 会话中通过工具直接调用",
+      "helpMessage": "码灵代码图谱提供代码搜索、调用链分析、节点详情等能力。\n\n接入方式：\n1. 在码灵代码图谱控制台(http://maling.weoa.com)接入项目\n2. 在 Agent 会话中通过工具直接调用",
       "enabled": true,
       "transport": {
         "type": "sse",

--- a/configs/channels/wb.json
+++ b/configs/channels/wb.json
@@ -9,7 +9,7 @@
   "windowTitle": "maling",
   "identifier": "local.maling.desktop",
   "updaterEndpoint": "http://maling.weoa.com/api/file/download/latest.json",
-  "updaterPublicKey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEE4Q0UzODdGMjIzN0Y0OTMKUldTVDlEY2lmempPcUsxM0xiR1poRDFPV1lVdVN5MlM5dzNLVURCcXlUK3hGeFlWeXFwL2JwOHcK",
+  "updaterPublicKey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEI4MjQyQ0JEQUUxMUNFOApSV1RvSE9IYXkwS0NDeS9mS0hhblROeC9yVFNaR01HVUpvTVBQamg4NWVESjI2U3I0OUNzcjRlLwo=",
   "allowHttpUpdater": true,
   "bundleTargets": ["nsis"],
   "releaseBaseUrl": "http://maling.weoa.com/api/file/download",
@@ -21,6 +21,7 @@
     {
       "id": "maling-code-graph",
       "name": "码灵代码图谱",
+      "helpMessage": "码灵代码图谱提供代码搜索、调用链分析、节点详情等能力。\n\n接入方式：\n1. 在码灵代码图谱控制台(地址：http://maling.weoa.com/)接入项目\n2. 在 Agent 会话中通过工具直接调用",
       "enabled": true,
       "transport": {
         "type": "sse",

--- a/configs/channels/wb.json
+++ b/configs/channels/wb.json
@@ -9,12 +9,24 @@
   "windowTitle": "maling",
   "identifier": "local.maling.desktop",
   "updaterEndpoint": "http://maling.weoa.com/api/file/download/latest.json",
-  "updaterPublicKey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEI4MjQyQ0JEQUUxMUNFOApSV1RvSE9IYXkwS0NDeS9mS0hhblROeC9yVFNaR01HVUpvTVBQamg4NWVESjI2U3I0OUNzcjRlLwo=",
+  "updaterPublicKey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEE4Q0UzODdGMjIzN0Y0OTMKUldTVDlEY2lmempPcUsxM0xiR1poRDFPV1lVdVN5MlM5dzNLVURCcXlUK3hGeFlWeXFwL2JwOHcK",
   "allowHttpUpdater": true,
   "bundleTargets": ["nsis"],
   "releaseBaseUrl": "http://maling.weoa.com/api/file/download",
   "metricsEnabled": true,
   "metricsToggleLocked": true,
   "metricsBaseUrl": "http://maling.weoa.com",
-  "metricsApiKey": ""
+  "metricsApiKey": "",
+  "builtinMcpServers": [
+    {
+      "id": "maling-code-graph",
+      "name": "码灵代码图谱",
+      "enabled": true,
+      "transport": {
+        "type": "sse",
+        "url": "http://maling.weoa.com/mcp/sse",
+        "headers": {}
+      }
+    }
+  ]
 }

--- a/docs/gold-band/产品设计文档/interaction/app/shell.md
+++ b/docs/gold-band/产品设计文档/interaction/app/shell.md
@@ -64,6 +64,7 @@ Agent 管理
 - 点击“任务编排”应回到任务列表根页面，而不是保留任务工作流或 Round 详情等深层页面。
 - 当前实现任务编排、Agent 管理、上下文管理和设置。
 - 上下文管理当前提供角色管理（Profile Management），用于维护工作流节点引用的 profile；列表拆成“自定义角色 / 内置角色”双 tab，自定义角色维护独立分页与过滤，内置角色单独浏览。内置角色与自定义角色卡片使用同一套紧凑密度基线，桌面常见宽度下优先维持一行 3 张卡片，再按宽度退化。浏览器预览 mock 与桌面端 Tauri 数据通路必须分层隔离，不能在正式路径复用 mock 状态；该分层由前端 Vitest 回归测试持续覆盖 runtime 选择、facade 透传和 desktop/browser 双实现语义。
+- 上下文管理的 MCP 管理页按“自定义 MCP / 内置 MCP”分段展示。自定义 MCP 允许用户新增、编辑、删除和启停；内置 MCP 由渠道配置注入，只允许用户查看、诊断、查看工具列表和启停，不能编辑或删除。内置 MCP 仅在对应渠道声明 `builtinMcpServers` 时注入，首次注入使用渠道配置的 `enabled` 默认值；后续启动同步只刷新名称、连接方式和帮助信息，必须保留用户在本机选择的启停状态。MCP 工具列表通过后端 `tools/list` 获取，stdio transport 必须在同一个子进程会话中先完成 `initialize`，再等待 `tools/list` 的 JSON-RPC 响应，不能把 initialize 响应误当作工具列表结果。
 - 模型管理保持占位，可显示 disabled 或 coming soon 状态。
 - 不在一级菜单中放 run、round、node 等任务内部对象。
 

--- a/docs/gold-band/开发计划/acp接入/acp功能模块todo列表.md
+++ b/docs/gold-band/开发计划/acp接入/acp功能模块todo列表.md
@@ -11,6 +11,7 @@
 - ACP prompt 会在发送 `session/prompt` 前持久化 synthetic `userTextDelta`，用于展示初始 prompt 和继续输入。
 - Raw frames 诊断读取已从普通 session 刷新路径中解耦，普通刷新只统计行数；详情视图按 JSONL 行做后端分页、关键词检索、direction 和 kind/method 过滤，默认打开最新页，不把全量 `acp.raw.jsonl` 传给前端。
 - ACP Message List 已使用内容尺寸监听补齐流式消息增高时的底部贴合，并限制只有非底部顶部预取区才加载更早历史，避免生成回复时误触发 prepend 后跳顶。
+- MCP 管理已支持 stdio / HTTP / SSE 三类 transport、渠道内置 MCP 注入和工具列表查看。内置 MCP 仅由声明 `builtinMcpServers` 的渠道启用；首次注入使用渠道默认 `enabled`，后续启动同步保留用户本机启停状态，只刷新托管配置内容。`tools/list` 走后端接口验收：stdio 在同一子进程会话中等待 initialize 响应后继续读取 tools/list 响应，避免把首个 JSON-RPC 响应误判为工具列表。
 
 ## 设计原则
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -20,6 +20,8 @@ struct ChannelConfig {
     #[serde(default)]
     metrics_base_url: String,
     metrics_api_key: String,
+    #[serde(default)]
+    builtin_mcp_servers: Vec<serde_json::Value>,
 }
 
 fn main() {
@@ -112,6 +114,8 @@ fn main() {
         "cargo:rustc-env=GOLD_BAND_SILENT_UPDATE_ENABLED={}",
         config.silent_update_enabled
     );
+    let builtin_mcp_json = serde_json::to_string(&config.builtin_mcp_servers).unwrap_or_default();
+    println!("cargo:rustc-env=GOLD_BAND_BUILTIN_MCP_SERVERS={builtin_mcp_json}");
 
     tauri_build::build()
 }

--- a/src-tauri/src/builtin_mcp.rs
+++ b/src-tauri/src/builtin_mcp.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 use tracing::{info, warn};
 
+use gold_band::config::McpServerState;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct BuiltinMcpServerDef {
@@ -117,4 +119,42 @@ pub fn inject_builtin_mcp_servers(state: &crate::state::DesktopState) {
             }
         }
     }
+}
+
+/// 启动后台线程对所有已启用的 MCP 服务器执行一次健康检查，结果写入共享缓存。
+/// 这样客户端启动后 MCP 服务的可用状态即被预探测，进入 MCP 管理页无需手动诊断。
+/// 健康检查为阻塞式网络/进程 I/O，放在独立线程避免卡住主线程。
+pub fn refresh_all_mcp_health(state: &crate::state::DesktopState) {
+    let Ok(ctx) = state.context() else { return };
+    let paths = gold_band::storage::GoldBandPaths::new(ctx.repo_root);
+    let mcp_mgr = gold_band::mcp::McpManager::new(paths.user_settings_file());
+    let Ok(servers) = mcp_mgr.list() else { return };
+
+    for s in servers {
+        if !s.config.enabled {
+            continue;
+        }
+        let id = s.config.id.clone();
+        let cache_state = match mcp_mgr.check_health(&id) {
+            Ok(result) => match result.status.as_str() {
+                "healthy" => McpServerState::Running {
+                    tools: result.tools.clone(),
+                },
+                "auth_required" => McpServerState::AuthRequired {
+                    auth_url: result.auth_url.clone(),
+                },
+                _ => McpServerState::Error {
+                    message: result
+                        .message
+                        .clone()
+                        .unwrap_or_else(|| "unknown error".into()),
+                },
+            },
+            Err(e) => McpServerState::Error { message: e.to_string() },
+        };
+        if let Err(e) = state.record_mcp_health(id.clone(), cache_state) {
+            warn!(server_id = %id, error = %e, "failed to record mcp health");
+        }
+    }
+    info!("startup mcp health check completed");
 }

--- a/src-tauri/src/builtin_mcp.rs
+++ b/src-tauri/src/builtin_mcp.rs
@@ -10,13 +10,15 @@ struct BuiltinMcpServerDef {
     id: String,
     name: String,
     #[serde(default = "default_enabled")]
-    _enabled: bool,
+    enabled: bool,
     transport: BuiltinMcpTransportDef,
     #[serde(default)]
     help_message: Option<String>,
 }
 
-fn default_enabled() -> bool { true }
+fn default_enabled() -> bool {
+    true
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -107,15 +109,17 @@ pub fn inject_builtin_mcp_servers(state: &crate::state::DesktopState) {
         let json = server.to_mcp_json();
         if existing_managed.contains(sid) {
             // Managed server already exists — update its config (name/transport may have changed)
-            match mcp_mgr.add_managed(&json) {
+            match mcp_mgr.add_managed(&json, server.enabled) {
                 Ok(_) => info!(server_id = %sid, "synced builtin MCP server config"),
                 Err(e) => warn!(server_id = %sid, error = %e, "failed to sync builtin MCP server"),
             }
         } else {
             // Not yet injected — add as new managed server
-            match mcp_mgr.add_managed(&json) {
+            match mcp_mgr.add_managed(&json, server.enabled) {
                 Ok(_) => info!(server_id = %sid, "injected builtin MCP server"),
-                Err(e) => warn!(server_id = %sid, error = %e, "failed to inject builtin MCP server"),
+                Err(e) => {
+                    warn!(server_id = %sid, error = %e, "failed to inject builtin MCP server")
+                }
             }
         }
     }
@@ -150,7 +154,9 @@ pub fn refresh_all_mcp_health(state: &crate::state::DesktopState) {
                         .unwrap_or_else(|| "unknown error".into()),
                 },
             },
-            Err(e) => McpServerState::Error { message: e.to_string() },
+            Err(e) => McpServerState::Error {
+                message: e.to_string(),
+            },
         };
         if let Err(e) = state.record_mcp_health(id.clone(), cache_state) {
             warn!(server_id = %id, error = %e, "failed to record mcp health");

--- a/src-tauri/src/builtin_mcp.rs
+++ b/src-tauri/src/builtin_mcp.rs
@@ -10,6 +10,8 @@ struct BuiltinMcpServerDef {
     #[serde(default = "default_enabled")]
     _enabled: bool,
     transport: BuiltinMcpTransportDef,
+    #[serde(default)]
+    help_message: Option<String>,
 }
 
 fn default_enabled() -> bool { true }
@@ -43,47 +45,38 @@ impl BuiltinMcpServerDef {
     fn to_mcp_json(&self) -> String {
         let id = self.id.as_str();
         let name = self.name.as_str();
-        match &self.transport {
+        let mut inner = match &self.transport {
             BuiltinMcpTransportDef::Stdio { command, args, env } => {
-                let mut map = serde_json::Map::new();
-                map.insert(
-                    id.to_owned(),
-                    serde_json::json!({
-                        "command": command,
-                        "args": args,
-                        "env": env,
-                        "name": name,
-                    }),
-                );
-                serde_json::to_string(&map).unwrap()
+                serde_json::json!({
+                    "command": command,
+                    "args": args,
+                    "env": env,
+                    "name": name,
+                })
             }
             BuiltinMcpTransportDef::Http { url, headers } => {
-                let mut map = serde_json::Map::new();
-                map.insert(
-                    id.to_owned(),
-                    serde_json::json!({
-                        "type": "http",
-                        "url": url,
-                        "headers": headers,
-                        "name": name,
-                    }),
-                );
-                serde_json::to_string(&map).unwrap()
+                serde_json::json!({
+                    "type": "http",
+                    "url": url,
+                    "headers": headers,
+                    "name": name,
+                })
             }
             BuiltinMcpTransportDef::Sse { url, headers } => {
-                let mut map = serde_json::Map::new();
-                map.insert(
-                    id.to_owned(),
-                    serde_json::json!({
-                        "type": "sse",
-                        "url": url,
-                        "headers": headers,
-                        "name": name,
-                    }),
-                );
-                serde_json::to_string(&map).unwrap()
+                serde_json::json!({
+                    "type": "sse",
+                    "url": url,
+                    "headers": headers,
+                    "name": name,
+                })
             }
+        };
+        if let Some(ref msg) = self.help_message {
+            inner["helpMessage"] = serde_json::json!(msg);
         }
+        let mut map = serde_json::Map::new();
+        map.insert(id.to_owned(), inner);
+        serde_json::to_string(&map).unwrap()
     }
 }
 

--- a/src-tauri/src/builtin_mcp.rs
+++ b/src-tauri/src/builtin_mcp.rs
@@ -1,0 +1,127 @@
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use tracing::{info, warn};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuiltinMcpServerDef {
+    id: String,
+    name: String,
+    #[serde(default = "default_enabled")]
+    _enabled: bool,
+    transport: BuiltinMcpTransportDef,
+}
+
+fn default_enabled() -> bool { true }
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum BuiltinMcpTransportDef {
+    #[serde(rename_all = "camelCase")]
+    Stdio {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default)]
+        env: BTreeMap<String, String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Http {
+        url: String,
+        #[serde(default)]
+        headers: BTreeMap<String, String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Sse {
+        url: String,
+        #[serde(default)]
+        headers: BTreeMap<String, String>,
+    },
+}
+
+impl BuiltinMcpServerDef {
+    fn to_mcp_json(&self) -> String {
+        let id = self.id.as_str();
+        let name = self.name.as_str();
+        match &self.transport {
+            BuiltinMcpTransportDef::Stdio { command, args, env } => {
+                let mut map = serde_json::Map::new();
+                map.insert(
+                    id.to_owned(),
+                    serde_json::json!({
+                        "command": command,
+                        "args": args,
+                        "env": env,
+                        "name": name,
+                    }),
+                );
+                serde_json::to_string(&map).unwrap()
+            }
+            BuiltinMcpTransportDef::Http { url, headers } => {
+                let mut map = serde_json::Map::new();
+                map.insert(
+                    id.to_owned(),
+                    serde_json::json!({
+                        "type": "http",
+                        "url": url,
+                        "headers": headers,
+                        "name": name,
+                    }),
+                );
+                serde_json::to_string(&map).unwrap()
+            }
+            BuiltinMcpTransportDef::Sse { url, headers } => {
+                let mut map = serde_json::Map::new();
+                map.insert(
+                    id.to_owned(),
+                    serde_json::json!({
+                        "type": "sse",
+                        "url": url,
+                        "headers": headers,
+                        "name": name,
+                    }),
+                );
+                serde_json::to_string(&map).unwrap()
+            }
+        }
+    }
+}
+
+pub fn inject_builtin_mcp_servers(state: &crate::state::DesktopState) {
+    let channel_config = crate::channel::current_channel_config();
+    let builtin_servers: Vec<BuiltinMcpServerDef> =
+        serde_json::from_str(channel_config.builtin_mcp_servers_json).unwrap_or_default();
+
+    if builtin_servers.is_empty() {
+        return;
+    }
+
+    let Ok(ctx) = state.context() else { return };
+    let paths = gold_band::storage::GoldBandPaths::new(ctx.repo_root);
+    let mcp_mgr = gold_band::mcp::McpManager::new(paths.user_settings_file());
+
+    let Ok(existing) = mcp_mgr.list() else { return };
+    let existing_managed: std::collections::HashSet<&str> = existing
+        .iter()
+        .filter(|s| s.config.managed)
+        .map(|s| s.config.id.as_str())
+        .collect();
+
+    for server in &builtin_servers {
+        let sid = server.id.as_str();
+        let json = server.to_mcp_json();
+        if existing_managed.contains(sid) {
+            // Managed server already exists — update its config (name/transport may have changed)
+            match mcp_mgr.add_managed(&json) {
+                Ok(_) => info!(server_id = %sid, "synced builtin MCP server config"),
+                Err(e) => warn!(server_id = %sid, error = %e, "failed to sync builtin MCP server"),
+            }
+        } else {
+            // Not yet injected — add as new managed server
+            match mcp_mgr.add_managed(&json) {
+                Ok(_) => info!(server_id = %sid, "injected builtin MCP server"),
+                Err(e) => warn!(server_id = %sid, error = %e, "failed to inject builtin MCP server"),
+            }
+        }
+    }
+}

--- a/src-tauri/src/channel.rs
+++ b/src-tauri/src/channel.rs
@@ -17,6 +17,7 @@ pub struct DesktopChannelConfig {
     pub metrics_base_url: &'static str,
     pub metrics_api_key: &'static str,
     pub silent_update_enabled: bool,
+    pub builtin_mcp_servers_json: &'static str,
 }
 
 pub fn current_channel_config() -> DesktopChannelConfig {
@@ -35,6 +36,7 @@ pub fn current_channel_config() -> DesktopChannelConfig {
         metrics_base_url: option_env!("GOLD_BAND_METRICS_BASE_URL").unwrap_or(""),
         metrics_api_key: option_env!("GOLD_BAND_METRICS_API_KEY").unwrap_or(""),
         silent_update_enabled: option_env!("GOLD_BAND_SILENT_UPDATE_ENABLED") == Some("true"),
+        builtin_mcp_servers_json: option_env!("GOLD_BAND_BUILTIN_MCP_SERVERS").unwrap_or("[]"),
     };
     eprintln!(
         "[metrics] compile-time channel={} metrics_enabled={} metrics_locked={} base_url={} apikey_set={}",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3262,8 +3262,10 @@ fn open_path(path: &std::path::Path) -> Result<(), String> {
 #[tauri::command]
 pub fn list_mcp_servers(state: State<'_, DesktopState>) -> CommandResult<Vec<McpServerVm>> {
     let app = state.app().map_err(command_error)?;
+    let health = state.mcp_health_snapshot().unwrap_or_default();
     Ok(mcp_server_list_vm(
         &app.list_mcp_servers().map_err(command_error)?,
+        &health,
     ))
 }
 
@@ -3276,8 +3278,10 @@ pub fn add_mcp_server(
     ensure_no_active_acp_prompts_in_workspace(&app.paths.repo_root)?;
     gold_band::acp::client::close_workspace_connections_bounded(&app.paths.repo_root)
         .map_err(command_error)?;
+    let health = state.mcp_health_snapshot().unwrap_or_default();
     Ok(mcp_server_list_vm(
         &app.add_mcp_server(&json_content).map_err(command_error)?,
+        &health,
     ))
 }
 
@@ -3291,9 +3295,11 @@ pub fn update_mcp_server(
     ensure_no_active_acp_prompts_in_workspace(&app.paths.repo_root)?;
     gold_band::acp::client::close_workspace_connections_bounded(&app.paths.repo_root)
         .map_err(command_error)?;
+    let health = state.mcp_health_snapshot().unwrap_or_default();
     Ok(mcp_server_list_vm(
         &app.update_mcp_server(&id, &json_content)
             .map_err(command_error)?,
+        &health,
     ))
 }
 
@@ -3306,8 +3312,10 @@ pub fn delete_mcp_server(
     ensure_no_active_acp_prompts_in_workspace(&app.paths.repo_root)?;
     gold_band::acp::client::close_workspace_connections_bounded(&app.paths.repo_root)
         .map_err(command_error)?;
+    let health = state.mcp_health_snapshot().unwrap_or_default();
     Ok(mcp_server_list_vm(
         &app.delete_mcp_server(&id).map_err(command_error)?,
+        &health,
     ))
 }
 
@@ -3321,27 +3329,66 @@ pub fn toggle_mcp_server(
     ensure_no_active_acp_prompts_in_workspace(&app.paths.repo_root)?;
     gold_band::acp::client::close_workspace_connections_bounded(&app.paths.repo_root)
         .map_err(command_error)?;
+    let health = state.mcp_health_snapshot().unwrap_or_default();
     Ok(mcp_server_list_vm(
         &app.toggle_mcp_server(&id, enabled).map_err(command_error)?,
+        &health,
     ))
 }
 
 #[tauri::command]
-pub fn check_mcp_server_health(
+pub async fn check_mcp_server_health(
     state: State<'_, DesktopState>,
     id: String,
 ) -> CommandResult<gold_band::config::McpServerHealthResult> {
-    let app = state.app().map_err(command_error)?;
-    app.check_mcp_server_health(&id).map_err(command_error)
+    // 健康检查包含阻塞式网络/进程 I/O，必须在 spawn_blocking 中执行，
+    // 否则同步 command 会卡住 webview 主线程（首次进入 MCP 管理时界面冻结的根因）。
+    let settings_path = {
+        let app = state.app().map_err(command_error)?;
+        app.paths.user_settings_file()
+    };
+    let id_for_cache = id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        gold_band::mcp::McpManager::new(settings_path)
+            .check_health(&id)
+            .map_err(command_error)
+    })
+    .await
+    .map_err(|e| command_error(anyhow::anyhow!("health check task failed: {e}")))??;
+    // 写入共享缓存，供列表 VM 展示（手动诊断与启动后台线程共用此入口）。
+    let cache_state = match result.status.as_str() {
+        "healthy" => gold_band::config::McpServerState::Running { tools: result.tools.clone() },
+        "auth_required" => gold_band::config::McpServerState::AuthRequired {
+            auth_url: result.auth_url.clone(),
+        },
+        _ => gold_band::config::McpServerState::Error {
+            message: result
+                .message
+                .clone()
+                .unwrap_or_else(|| "unknown error".into()),
+        },
+    };
+    let _ = state.record_mcp_health(id_for_cache, cache_state);
+    Ok(result)
 }
 
 #[tauri::command]
-pub fn list_mcp_tools(
+pub async fn list_mcp_tools(
     state: State<'_, DesktopState>,
     id: String,
 ) -> CommandResult<Vec<gold_band::config::ToolInfo>> {
-    let app = state.app().map_err(command_error)?;
-    app.list_mcp_tools(&id).map_err(command_error)
+    // tools/list 同样包含阻塞式 I/O（SSE 长连接 + HTTP），需放到 spawn_blocking。
+    let settings_path = {
+        let app = state.app().map_err(command_error)?;
+        app.paths.user_settings_file()
+    };
+    tauri::async_runtime::spawn_blocking(move || {
+        gold_band::mcp::McpManager::new(settings_path)
+            .list_tools(&id)
+            .map_err(command_error)
+    })
+    .await
+    .map_err(|e| command_error(anyhow::anyhow!("list tools task failed: {e}")))?
 }
 
 // ── SKILL Commands ──

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3335,6 +3335,15 @@ pub fn check_mcp_server_health(
     app.check_mcp_server_health(&id).map_err(command_error)
 }
 
+#[tauri::command]
+pub fn list_mcp_tools(
+    state: State<'_, DesktopState>,
+    id: String,
+) -> CommandResult<Vec<gold_band::config::ToolInfo>> {
+    let app = state.app().map_err(command_error)?;
+    app.list_mcp_tools(&id).map_err(command_error)
+}
+
 // ── SKILL Commands ──
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -106,6 +106,13 @@ fn run() -> anyhow::Result<()> {
                     std::thread::sleep(std::time::Duration::from_secs(60));
                 }
             });
+            // 启动后台线程预探测 MCP 服务健康状态（独立线程，避免阻塞 webview 主线程）。
+            // 客户端启动后即开始检测，进入 MCP 管理页时状态已就绪，无需手动诊断。
+            let health_handle = app.handle().clone();
+            std::thread::spawn(move || {
+                let state = health_handle.state::<DesktopState>();
+                builtin_mcp::refresh_all_mcp_health(&state);
+            });
             retry_pending_startup_install(&app.handle().clone());
             start_update_polling(app.handle().clone());
             start_heartbeat_polling(app.handle().clone());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod builtin_mcp;
 mod channel;
 mod commands;
 mod commands_conversation;
@@ -16,6 +17,7 @@ use commands::{
     add_mcp_server, cancel_acp_session, check_local_claude, check_mcp_server_health,
     check_update_manual, choose_workspace, continue_run, create_agent, create_profile, create_task,
     delete_agent, delete_auto_template, delete_mcp_server, delete_profile, delete_skill,
+    list_mcp_tools,
     delete_workflow_template, dismiss_update_announcement, doctor_agent,
     download_and_install_update, get_acp_raw_frames, get_acp_session, get_agent_registry,
     get_app_bootstrap, get_auto_templates, get_log_page, get_metrics_settings, get_profile,
@@ -93,6 +95,7 @@ fn run() -> anyhow::Result<()> {
                     needs_workspace = ctx.needs_workspace,
                     "desktop runtime initialized"
                 );
+                builtin_mcp::inject_builtin_mcp_servers(&state);
                 let _ = init_search_index(&paths.sqlite_db_path(), &paths.projects_dir());
             }
             let handle = app.handle().clone();
@@ -225,6 +228,7 @@ fn run() -> anyhow::Result<()> {
             delete_mcp_server,
             toggle_mcp_server,
             check_mcp_server_health,
+            list_mcp_tools,
             list_skills,
             list_project_skills,
             read_skill,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -179,6 +179,8 @@ pub struct DesktopState {
     notification_attention: Mutex<NotificationAttentionState>,
     /// 干预通知去重表（弹窗层统一管理，路径 A/B 共享同一实例）。
     notification_dedup: Arc<NotificationDedup>,
+    /// MCP 服务器健康状态缓存（启动后台线程 + 手动诊断共同写入，列表读取）。
+    mcp_health: Mutex<BTreeMap<String, gold_band::config::McpServerState>>,
 }
 
 impl DesktopState {
@@ -192,7 +194,30 @@ impl DesktopState {
             pending_critical_update: Mutex::new(None),
             notification_attention: Mutex::new(NotificationAttentionState::default()),
             notification_dedup: Arc::new(NotificationDedup::new()),
+            mcp_health: Mutex::new(BTreeMap::new()),
         }
+    }
+
+    /// 读取 MCP 健康状态缓存快照（供列表 VM 附加展示）。
+    pub fn mcp_health_snapshot(&self) -> Result<BTreeMap<String, gold_band::config::McpServerState>> {
+        Ok(self
+            .mcp_health
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mcp health lock poisoned"))?
+            .clone())
+    }
+
+    /// 写入/更新单个 MCP 服务器的健康状态（启动后台线程与诊断命令共用）。
+    pub fn record_mcp_health(
+        &self,
+        id: String,
+        state: gold_band::config::McpServerState,
+    ) -> Result<()> {
+        self.mcp_health
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mcp health lock poisoned"))?
+            .insert(id, state);
+        Ok(())
     }
 
     /// 干预通知去重表（共享实例）。路径 A/B 与 dismiss 命令均经此访问。

--- a/src-tauri/src/view_models.rs
+++ b/src-tauri/src/view_models.rs
@@ -10,7 +10,8 @@ use anyhow::Result;
 use gold_band::app::{App, LogSource, TaskSummary, is_run_continuable};
 use gold_band::config::{
     DesktopAvailableUpdate, DesktopFontPreference, DesktopLanguage, DesktopThemePreference,
-    DesktopUpdateBadgeState, ManagedAgentConfig, ManagedAgentType, RuntimeConfig, RuntimeLogLevel,
+    DesktopUpdateBadgeState, ManagedAgentConfig, ManagedAgentType, McpServerState, RuntimeConfig,
+    RuntimeLogLevel,
 };
 use gold_band::domain::{NodeType, RunOutcome, RunStatus, SessionMode};
 use gold_band::dsl::{NodeDsl, WorkflowDsl, WorkflowValidationError};
@@ -5383,7 +5384,10 @@ fn newest_first<T>(mut items: Vec<T>) -> Vec<T> {
 
 // ── MCP Server VM ──
 
-pub fn mcp_server_list_vm(servers: &[gold_band::config::McpServerConfig]) -> Vec<McpServerVm> {
+pub fn mcp_server_list_vm(
+    servers: &[gold_band::config::McpServerConfig],
+    health: &std::collections::BTreeMap<String, McpServerState>,
+) -> Vec<McpServerVm> {
     servers
         .iter()
         .map(|s| {
@@ -5421,6 +5425,18 @@ pub fn mcp_server_list_vm(servers: &[gold_band::config::McpServerConfig]) -> Vec
                     Some(env_to_entries(h)),
                 ),
             };
+            let (health_status, health_message) = match health.get(&s.id) {
+                Some(McpServerState::Running { .. }) => (Some("healthy".to_string()), None),
+                Some(McpServerState::Error { message }) => {
+                    (Some("unhealthy".to_string()), Some(message.clone()))
+                }
+                Some(McpServerState::AuthRequired { auth_url }) => {
+                    (Some("auth_required".to_string()), auth_url.clone())
+                }
+                Some(McpServerState::Stopped) => (Some("stopped".to_string()), None),
+                Some(McpServerState::Starting) => (Some("checking".to_string()), None),
+                None => (None, None),
+            };
             McpServerVm {
                 id: s.id.clone(),
                 name: s.name.clone(),
@@ -5433,8 +5449,8 @@ pub fn mcp_server_list_vm(servers: &[gold_band::config::McpServerConfig]) -> Vec
                 headers,
                 managed: s.managed,
                 help_message: s.help_message.clone(),
-                health_status: None,
-                health_message: None,
+                health_status,
+                health_message,
             }
         })
         .collect()

--- a/src-tauri/src/view_models.rs
+++ b/src-tauri/src/view_models.rs
@@ -136,6 +136,7 @@ pub struct McpServerVm {
     pub env: Option<Vec<AgentEnvEntryVm>>,
     pub url: Option<String>,
     pub headers: Option<Vec<AgentEnvEntryVm>>,
+    pub managed: bool,
     pub health_status: Option<String>, // "healthy" | "unhealthy" | "unknown"
     pub health_message: Option<String>,
 }
@@ -5408,6 +5409,16 @@ pub fn mcp_server_list_vm(servers: &[gold_band::config::McpServerConfig]) -> Vec
                     Some(u.clone()),
                     Some(env_to_entries(h)),
                 ),
+                gold_band::config::McpTransportConfig::Sse {
+                    url: u, headers: h,
+                } => (
+                    "sse".to_string(),
+                    None,
+                    None,
+                    None,
+                    Some(u.clone()),
+                    Some(env_to_entries(h)),
+                ),
             };
             McpServerVm {
                 id: s.id.clone(),
@@ -5419,6 +5430,7 @@ pub fn mcp_server_list_vm(servers: &[gold_band::config::McpServerConfig]) -> Vec
                 env,
                 url,
                 headers,
+                managed: s.managed,
                 health_status: None,
                 health_message: None,
             }

--- a/src-tauri/src/view_models.rs
+++ b/src-tauri/src/view_models.rs
@@ -137,6 +137,7 @@ pub struct McpServerVm {
     pub url: Option<String>,
     pub headers: Option<Vec<AgentEnvEntryVm>>,
     pub managed: bool,
+    pub help_message: Option<String>,
     pub health_status: Option<String>, // "healthy" | "unhealthy" | "unknown"
     pub health_message: Option<String>,
 }
@@ -5431,6 +5432,7 @@ pub fn mcp_server_list_vm(servers: &[gold_band::config::McpServerConfig]) -> Vec
                 url,
                 headers,
                 managed: s.managed,
+                help_message: s.help_message.clone(),
                 health_status: None,
                 health_message: None,
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1053,6 +1053,10 @@ impl App {
         self.mcp_manager().check_health(id)
     }
 
+    pub fn list_mcp_tools(&self, id: &str) -> Result<Vec<crate::config::ToolInfo>> {
+        self.mcp_manager().list_tools(id)
+    }
+
     pub fn enabled_mcp_servers(&self) -> Result<Vec<McpServerConfig>> {
         self.mcp_manager().enabled_servers()
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -335,6 +335,9 @@ pub struct McpServerConfig {
     pub enabled: bool,
     #[serde(flatten)]
     pub transport: McpTransportConfig,
+    /// 托管服务器 — 用户不可编辑/删除，由系统自动管理
+    #[serde(default)]
+    pub managed: bool,
 }
 
 fn default_enabled() -> bool {
@@ -367,6 +370,11 @@ pub enum McpTransportConfig {
         /// 对标 Zed: OAuth 预注册客户端配置
         #[serde(skip_serializing_if = "Option::is_none")]
         oauth: Option<OAuthClientConfig>,
+    },
+    Sse {
+        url: String,
+        #[serde(default)]
+        headers: BTreeMap<String, String>,
     },
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -335,9 +335,10 @@ pub struct McpServerConfig {
     pub enabled: bool,
     #[serde(flatten)]
     pub transport: McpTransportConfig,
-    /// 托管服务器 — 用户不可编辑/删除，由系统自动管理
     #[serde(default)]
     pub managed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub help_message: Option<String>,
 }
 
 fn default_enabled() -> bool {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use camino::Utf8PathBuf;
@@ -158,18 +158,24 @@ impl McpManager {
     pub fn add_managed(
         &self,
         json_content: &str,
+        default_enabled: bool,
     ) -> Result<(McpServerWithStatus, Vec<McpServerWithStatus>)> {
         let (id, transport, display_name, help_message) = parse_mcp_json(json_content)?;
+        let mut settings = self.load_settings()?;
+        let mut servers = settings.context_servers.unwrap_or_default();
+        let enabled = servers
+            .iter()
+            .find(|s| s.id == id && s.managed)
+            .map(|s| s.enabled)
+            .unwrap_or(default_enabled);
         let config = McpServerConfig {
             name: display_name.unwrap_or_else(|| id.clone()),
             id,
-            enabled: true,
+            enabled,
             transport,
             managed: true,
             help_message,
         };
-        let mut settings = self.load_settings()?;
-        let mut servers = settings.context_servers.unwrap_or_default();
         servers.retain(|s| s.id != config.id);
         servers.push(config.clone());
         settings.context_servers = Some(servers);
@@ -234,7 +240,11 @@ impl McpManager {
     pub fn delete(&self, id: &str) -> Result<Vec<McpServerWithStatus>> {
         let mut settings = self.load_settings()?;
         // Check managed before mutation — borrow then move
-        if let Some(s) = settings.context_servers.as_ref().and_then(|servers| servers.iter().find(|s| s.id == id)) {
+        if let Some(s) = settings
+            .context_servers
+            .as_ref()
+            .and_then(|servers| servers.iter().find(|s| s.id == id))
+        {
             anyhow::ensure!(
                 !s.managed,
                 "MCP server `{id}` is managed and cannot be deleted"
@@ -312,12 +322,8 @@ impl McpManager {
             McpTransportConfig::Stdio { command, args, env } => {
                 fetch_stdio_tools(command, args, env)
             }
-            McpTransportConfig::Http { url, headers, .. } => {
-                fetch_http_tools(url, headers)
-            }
-            McpTransportConfig::Sse { url, headers } => {
-                fetch_sse_tools(url, headers)
-            }
+            McpTransportConfig::Http { url, headers, .. } => fetch_http_tools(url, headers),
+            McpTransportConfig::Sse { url, headers } => fetch_sse_tools(url, headers),
         }
     }
 
@@ -630,9 +636,7 @@ fn verify_sse_server(
         .build()
         .context("failed to create HTTP client")?;
 
-    let mut req = client
-        .get(url)
-        .header("Accept", "text/event-stream");
+    let mut req = client.get(url).header("Accept", "text/event-stream");
 
     for (k, v) in headers {
         req = req.header(k.as_str(), v.as_str());
@@ -674,9 +678,43 @@ fn build_tools_list_request() -> Value {
     })
 }
 
+fn jsonrpc_response_id(response_text: &str) -> Option<u64> {
+    let value: Value = serde_json::from_str(response_text.trim()).ok()?;
+    value
+        .get("id")
+        .and_then(|id| id.as_u64().or_else(|| id.as_str()?.parse::<u64>().ok()))
+}
+
+fn recv_jsonrpc_response(
+    rx: &mpsc::Receiver<std::io::Result<String>>,
+    expected_id: u64,
+    timeout: Duration,
+    label: &str,
+) -> Result<String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            bail!("{label} timed out");
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        let text = match rx.recv_timeout(remaining) {
+            Ok(Ok(text)) => text,
+            Ok(Err(e)) => {
+                return Err(e).with_context(|| format!("failed to read {label} response"));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => bail!("{label} timed out"),
+            Err(mpsc::RecvTimeoutError::Disconnected) => bail!("{label} response stream closed"),
+        };
+        if jsonrpc_response_id(&text) == Some(expected_id) {
+            return Ok(text);
+        }
+    }
+}
+
 fn parse_tools_list_response(response_text: &str) -> Result<Vec<crate::config::ToolInfo>> {
-    let response: Value =
-        serde_json::from_str(response_text.trim()).context("invalid JSON response for tools/list")?;
+    let response: Value = serde_json::from_str(response_text.trim())
+        .context("invalid JSON response for tools/list")?;
     if let Some(err) = response.get("error") {
         let msg = err
             .get("message")
@@ -698,7 +736,10 @@ fn parse_tools_list_response(response_text: &str) -> Result<Vec<crate::config::T
                     .and_then(Value::as_str)
                     .context("tool missing name")?
                     .to_string(),
-                description: t.get("description").and_then(Value::as_str).map(String::from),
+                description: t
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .map(String::from),
                 input_schema: t.get("inputSchema").cloned(),
             })
         })
@@ -726,11 +767,6 @@ fn fetch_stdio_tools(
     let mut stdin = child.stdin.take().context("failed to capture stdin")?;
     let stdout = child.stdout.take().context("failed to capture stdout")?;
 
-    // Step 1: initialize
-    let init_line = serde_json::to_string(&build_initialize_request())? + "\n";
-    stdin.write_all(init_line.as_bytes())?;
-    stdin.flush()?;
-
     let (tx, rx) = mpsc::channel();
     let stdout_reader = std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
@@ -739,8 +775,9 @@ fn fetch_stdio_tools(
                 Ok(text) => {
                     let trimmed = text.trim().to_string();
                     if !trimmed.is_empty() {
-                        let _ = tx.send(Ok(trimmed));
-                        return;
+                        if tx.send(Ok(trimmed)).is_err() {
+                            return;
+                        }
                     }
                 }
                 Err(e) => {
@@ -755,27 +792,29 @@ fn fetch_stdio_tools(
         )));
     });
 
-    let _init_response = rx
-        .recv_timeout(Duration::from_secs(10))
-        .context("initialize timed out")?
-        .context("failed to read initialize response")?;
+    let result = (|| -> Result<Vec<crate::config::ToolInfo>> {
+        // Step 1: initialize
+        let init_line = serde_json::to_string(&build_initialize_request())? + "\n";
+        stdin.write_all(init_line.as_bytes())?;
+        stdin.flush()?;
+        let init_response = recv_jsonrpc_response(&rx, 1, Duration::from_secs(10), "initialize")?;
+        parse_initialize_response(&init_response).context("initialize failed")?;
 
-    // Step 2: tools/list
-    let tools_line = serde_json::to_string(&build_tools_list_request())? + "\n";
-    stdin.write_all(tools_line.as_bytes())?;
-    stdin.flush()?;
-    drop(stdin);
+        // Step 2: tools/list
+        let tools_line = serde_json::to_string(&build_tools_list_request())? + "\n";
+        stdin.write_all(tools_line.as_bytes())?;
+        stdin.flush()?;
+        drop(stdin);
 
-    let tools_response = rx
-        .recv_timeout(Duration::from_secs(10))
-        .context("tools/list timed out")?
-        .context("failed to read tools/list response")?;
+        let tools_response = recv_jsonrpc_response(&rx, 2, Duration::from_secs(10), "tools/list")?;
+        parse_tools_list_response(&tools_response)
+    })();
 
-    let _ = stdout_reader.join();
     let _ = child.kill();
     let _ = child.wait();
+    let _ = stdout_reader.join();
 
-    parse_tools_list_response(&tools_response)
+    result
 }
 
 fn fetch_http_tools(
@@ -821,7 +860,9 @@ fn fetch_sse_tools(
 
     use std::io::Read;
     let mut buf = [0u8; 8192];
-    let n = resp.read(&mut buf).context("failed to read SSE handshake")?;
+    let n = resp
+        .read(&mut buf)
+        .context("failed to read SSE handshake")?;
     let sse_body = String::from_utf8_lossy(&buf[..n]);
     let endpoint_url = discover_sse_endpoint(&sse_body, &base_url)
         .context("SSE handshake did not contain an endpoint event")?;
@@ -987,7 +1028,9 @@ fn try_oauth_discovery(
 
 // ── JSON Parser（对标 Zed parse_input / parse_http_input） ──
 
-fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig, Option<String>, Option<String>)> {
+fn parse_mcp_json(
+    json_content: &str,
+) -> Result<(String, McpTransportConfig, Option<String>, Option<String>)> {
     let stripped: String = json_content
         .lines()
         .filter(|line| !line.trim().starts_with("///"))
@@ -1025,4 +1068,200 @@ fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig, Opt
         }
     };
     Ok((id, transport, display_name, help_message))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::read_json;
+    use std::fs;
+
+    fn settings_path(temp: &tempfile::TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(temp.path().join("settings.json")).unwrap()
+    }
+
+    #[test]
+    fn managed_upsert_preserves_existing_enabled_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = settings_path(&temp);
+        let initial = SettingsConfig {
+            context_servers: Some(vec![McpServerConfig {
+                id: "managed-code-graph".into(),
+                name: "Old".into(),
+                enabled: false,
+                transport: McpTransportConfig::Stdio {
+                    command: "missing-old-command".into(),
+                    args: Vec::new(),
+                    env: BTreeMap::new(),
+                },
+                managed: true,
+                help_message: None,
+            }]),
+            ..SettingsConfig::default()
+        };
+        write_json(&settings_path, &initial).unwrap();
+
+        let manager = McpManager::new(settings_path.clone());
+        manager
+            .add_managed(
+                r#"{
+                  "managed-code-graph": {
+                    "command": "missing-new-command",
+                    "name": "Code Graph",
+                    "helpMessage": "Open the graph console before use"
+                  }
+                }"#,
+                true,
+            )
+            .unwrap();
+
+        let settings: SettingsConfig = read_json(&settings_path).unwrap();
+        let server = settings
+            .context_servers
+            .unwrap()
+            .into_iter()
+            .find(|s| s.id == "managed-code-graph")
+            .unwrap();
+        assert!(!server.enabled);
+        assert!(server.managed);
+        assert_eq!(server.name, "Code Graph");
+        assert_eq!(
+            server.help_message.as_deref(),
+            Some("Open the graph console before use")
+        );
+        match server.transport {
+            McpTransportConfig::Stdio { command, .. } => {
+                assert_eq!(command, "missing-new-command");
+            }
+            _ => panic!("expected stdio transport"),
+        }
+    }
+
+    #[test]
+    fn managed_insert_uses_channel_default_enabled() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = settings_path(&temp);
+        let manager = McpManager::new(settings_path.clone());
+
+        manager
+            .add_managed(
+                r#"{
+                  "disabled-by-channel": {
+                    "command": "missing-command",
+                    "name": "Disabled By Channel"
+                  }
+                }"#,
+                false,
+            )
+            .unwrap();
+
+        let settings: SettingsConfig = read_json(&settings_path).unwrap();
+        let server = settings.context_servers.unwrap().pop().unwrap();
+        assert_eq!(server.id, "disabled-by-channel");
+        assert!(!server.enabled);
+        assert!(server.managed);
+    }
+
+    #[test]
+    fn parses_sse_transport_name_and_help_message() {
+        let (id, transport, name, help_message) = parse_mcp_json(
+            r#"{
+              "code-graph": {
+                "type": "sse",
+                "url": "https://example.test/mcp/sse",
+                "headers": { "Authorization": "Bearer token" },
+                "name": "Code Graph",
+                "helpMessage": "Use this after project indexing finishes"
+              }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(id, "code-graph");
+        assert_eq!(name.as_deref(), Some("Code Graph"));
+        assert_eq!(
+            help_message.as_deref(),
+            Some("Use this after project indexing finishes")
+        );
+        match transport {
+            McpTransportConfig::Sse { url, headers } => {
+                assert_eq!(url, "https://example.test/mcp/sse");
+                assert_eq!(
+                    headers.get("Authorization").map(String::as_str),
+                    Some("Bearer token")
+                );
+            }
+            _ => panic!("expected sse transport"),
+        }
+    }
+
+    #[test]
+    fn stdio_tools_list_waits_for_response_after_initialize() {
+        let temp = tempfile::tempdir().unwrap();
+        let (command, args) = stdio_fixture_command(&temp);
+
+        let tools = fetch_stdio_tools(&command, &args, &BTreeMap::new()).unwrap();
+
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "lookup");
+        assert_eq!(tools[0].description.as_deref(), Some("Lookup"));
+        assert_eq!(
+            tools[0].input_schema.as_ref().and_then(|s| s.get("type")),
+            Some(&serde_json::json!("object"))
+        );
+    }
+
+    #[cfg(windows)]
+    fn stdio_fixture_command(temp: &tempfile::TempDir) -> (String, Vec<String>) {
+        let script = temp.path().join("mcp-fixture.ps1");
+        fs::write(
+            &script,
+            r#"
+while ($null -ne ($line = [Console]::In.ReadLine())) {
+  if ($line -like '*initialize*') {
+    [Console]::Out.WriteLine('{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"capabilities":{},"serverInfo":{"name":"fixture","version":"1"}}}')
+    [Console]::Out.Flush()
+  } elseif ($line -like '*tools/list*') {
+    [Console]::Out.WriteLine('{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"lookup","description":"Lookup","inputSchema":{"type":"object"}}]}}')
+    [Console]::Out.Flush()
+    break
+  }
+}
+"#,
+        )
+        .unwrap();
+        (
+            "powershell".into(),
+            vec![
+                "-NoProfile".into(),
+                "-ExecutionPolicy".into(),
+                "Bypass".into(),
+                "-File".into(),
+                script.to_string_lossy().into_owned(),
+            ],
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn stdio_fixture_command(temp: &tempfile::TempDir) -> (String, Vec<String>) {
+        let script = temp.path().join("mcp-fixture.sh");
+        fs::write(
+            &script,
+            r#"
+while IFS= read -r line; do
+  case "$line" in
+    *initialize*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"capabilities":{},"serverInfo":{"name":"fixture","version":"1"}}}'
+      ;;
+    *tools/list*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"lookup","description":"Lookup","inputSchema":{"type":"object"}}]}}'
+      break
+      ;;
+  esac
+done
+"#,
+        )
+        .unwrap();
+        ("sh".into(), vec![script.to_string_lossy().into_owned()])
+    }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -61,9 +61,10 @@ struct McpJsonEntry {
     headers: BTreeMap<String, String>,
     #[serde(default)]
     oauth: Option<OAuthClientConfig>,
-    /// 可选的展示名称，仅用于内置注入
     #[serde(default)]
     name: Option<String>,
+    #[serde(rename = "helpMessage", default)]
+    help_message: Option<String>,
 }
 
 impl McpManager {
@@ -125,13 +126,14 @@ impl McpManager {
         &self,
         json_content: &str,
     ) -> Result<(McpServerWithStatus, Vec<McpServerWithStatus>)> {
-        let (id, transport, display_name) = parse_mcp_json(json_content)?;
+        let (id, transport, display_name, help_message) = parse_mcp_json(json_content)?;
         let config = McpServerConfig {
             name: display_name.unwrap_or_else(|| id.clone()),
             id,
             enabled: true,
             transport,
             managed: false,
+            help_message,
         };
         let mut settings = self.load_settings()?;
         let mut servers = settings.context_servers.unwrap_or_default();
@@ -157,13 +159,14 @@ impl McpManager {
         &self,
         json_content: &str,
     ) -> Result<(McpServerWithStatus, Vec<McpServerWithStatus>)> {
-        let (id, transport, display_name) = parse_mcp_json(json_content)?;
+        let (id, transport, display_name, help_message) = parse_mcp_json(json_content)?;
         let config = McpServerConfig {
             name: display_name.unwrap_or_else(|| id.clone()),
             id,
             enabled: true,
             transport,
             managed: true,
+            help_message,
         };
         let mut settings = self.load_settings()?;
         let mut servers = settings.context_servers.unwrap_or_default();
@@ -200,13 +203,14 @@ impl McpManager {
                 "MCP server `{id}` is managed and cannot be modified"
             );
         }
-        let (new_id, transport, display_name) = parse_mcp_json(json_content)?;
+        let (new_id, transport, display_name, help_message) = parse_mcp_json(json_content)?;
         let config = McpServerConfig {
             name: display_name.unwrap_or_else(|| new_id.clone()),
             id: new_id,
             enabled: true,
             transport,
             managed: false,
+            help_message,
         };
         let mut settings = self.load_settings()?;
         let mut servers = settings.context_servers.unwrap_or_default();
@@ -983,7 +987,7 @@ fn try_oauth_discovery(
 
 // ── JSON Parser（对标 Zed parse_input / parse_http_input） ──
 
-fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig, Option<String>)> {
+fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig, Option<String>, Option<String>)> {
     let stripped: String = json_content
         .lines()
         .filter(|line| !line.trim().starts_with("///"))
@@ -998,6 +1002,7 @@ fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig, Opt
     );
     let (id, entry) = value.into_iter().next().unwrap();
     let display_name = entry.name.filter(|n| !n.is_empty());
+    let help_message = entry.help_message.filter(|m| !m.is_empty());
     let transport = if let Some(url) = entry.url {
         match entry.transport_type.as_deref() {
             Some("sse") => McpTransportConfig::Sse {
@@ -1019,5 +1024,5 @@ fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig, Opt
             env: entry.env,
         }
     };
-    Ok((id, transport, display_name))
+    Ok((id, transport, display_name, help_message))
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -55,10 +55,15 @@ struct McpJsonEntry {
     #[serde(default)]
     env: BTreeMap<String, String>,
     url: Option<String>,
+    #[serde(rename = "type", default)]
+    transport_type: Option<String>,
     #[serde(default)]
     headers: BTreeMap<String, String>,
     #[serde(default)]
     oauth: Option<OAuthClientConfig>,
+    /// 可选的展示名称，仅用于内置注入
+    #[serde(default)]
+    name: Option<String>,
 }
 
 impl McpManager {
@@ -120,12 +125,45 @@ impl McpManager {
         &self,
         json_content: &str,
     ) -> Result<(McpServerWithStatus, Vec<McpServerWithStatus>)> {
-        let (id, transport) = parse_mcp_json(json_content)?;
+        let (id, transport, display_name) = parse_mcp_json(json_content)?;
         let config = McpServerConfig {
-            name: id.clone(),
+            name: display_name.unwrap_or_else(|| id.clone()),
             id,
             enabled: true,
             transport,
+            managed: false,
+        };
+        let mut settings = self.load_settings()?;
+        let mut servers = settings.context_servers.unwrap_or_default();
+        servers.retain(|s| s.id != config.id);
+        servers.push(config.clone());
+        settings.context_servers = Some(servers);
+        self.save_settings(&settings)?;
+
+        let status = self.verify_server(&config);
+        let list = self.list()?;
+        Ok((
+            McpServerWithStatus {
+                config,
+                health_status: status.as_ref().ok().map(|_| "healthy".into()),
+                health_message: status.as_ref().ok().and_then(|r| r.message.clone()),
+            },
+            list,
+        ))
+    }
+
+    /// 对标 add()，但标记为 managed（托管），用户不可删除
+    pub fn add_managed(
+        &self,
+        json_content: &str,
+    ) -> Result<(McpServerWithStatus, Vec<McpServerWithStatus>)> {
+        let (id, transport, display_name) = parse_mcp_json(json_content)?;
+        let config = McpServerConfig {
+            name: display_name.unwrap_or_else(|| id.clone()),
+            id,
+            enabled: true,
+            transport,
+            managed: true,
         };
         let mut settings = self.load_settings()?;
         let mut servers = settings.context_servers.unwrap_or_default();
@@ -151,12 +189,24 @@ impl McpManager {
         id: &str,
         json_content: &str,
     ) -> Result<(McpServerWithStatus, Vec<McpServerWithStatus>)> {
-        let (new_id, transport) = parse_mcp_json(json_content)?;
+        let settings = self.load_settings()?;
+        if let Some(s) = settings
+            .context_servers
+            .as_ref()
+            .and_then(|servers| servers.iter().find(|s| s.id == id))
+        {
+            anyhow::ensure!(
+                !s.managed,
+                "MCP server `{id}` is managed and cannot be modified"
+            );
+        }
+        let (new_id, transport, display_name) = parse_mcp_json(json_content)?;
         let config = McpServerConfig {
-            name: new_id.clone(),
+            name: display_name.unwrap_or_else(|| new_id.clone()),
             id: new_id,
             enabled: true,
             transport,
+            managed: false,
         };
         let mut settings = self.load_settings()?;
         let mut servers = settings.context_servers.unwrap_or_default();
@@ -179,6 +229,13 @@ impl McpManager {
 
     pub fn delete(&self, id: &str) -> Result<Vec<McpServerWithStatus>> {
         let mut settings = self.load_settings()?;
+        // Check managed before mutation — borrow then move
+        if let Some(s) = settings.context_servers.as_ref().and_then(|servers| servers.iter().find(|s| s.id == id)) {
+            anyhow::ensure!(
+                !s.managed,
+                "MCP server `{id}` is managed and cannot be deleted"
+            );
+        }
         let mut servers = settings.context_servers.unwrap_or_default();
         servers.retain(|s| s.id != id);
         settings.context_servers = Some(servers);
@@ -239,7 +296,28 @@ impl McpManager {
         self.state_cache.borrow_mut().remove(id);
     }
 
-    /// 对标 Zed server.start() — Stdio 发送 MCP initialize 请求; HTTP 实际请求
+    /// 拉取 MCP 服务器的工具列表（tools/list）
+    pub fn list_tools(&self, id: &str) -> Result<Vec<crate::config::ToolInfo>> {
+        let settings = self.load_settings()?;
+        let config = settings
+            .context_servers
+            .as_ref()
+            .and_then(|servers| servers.iter().find(|s| s.id == id))
+            .with_context(|| format!("MCP server `{id}` not found"))?;
+        match &config.transport {
+            McpTransportConfig::Stdio { command, args, env } => {
+                fetch_stdio_tools(command, args, env)
+            }
+            McpTransportConfig::Http { url, headers, .. } => {
+                fetch_http_tools(url, headers)
+            }
+            McpTransportConfig::Sse { url, headers } => {
+                fetch_sse_tools(url, headers)
+            }
+        }
+    }
+
+    /// 对标 Zed server.start() — Stdio 发送 MCP initialize 请求; HTTP/SSE 实际请求
     fn verify_server(&self, config: &McpServerConfig) -> Result<McpServerHealthResult> {
         match &config.transport {
             McpTransportConfig::Stdio { command, args, env } => {
@@ -250,6 +328,7 @@ impl McpManager {
                 headers,
                 oauth,
             } => verify_http_server(url, headers, oauth),
+            McpTransportConfig::Sse { url, headers } => verify_sse_server(url, headers),
         }
     }
 
@@ -337,6 +416,15 @@ impl McpManager {
                         });
                     }
                     json
+                }
+                McpTransportConfig::Sse { url, headers } => {
+                    serde_json::json!({
+                        "id": s.id,
+                        "name": s.name,
+                        "transport": "sse",
+                        "url": url,
+                        "headers": headers,
+                    })
                 }
             })
             .collect())
@@ -525,6 +613,297 @@ fn verify_http_server(
     }
 }
 
+fn verify_sse_server(
+    url: &str,
+    headers: &BTreeMap<String, String>,
+) -> Result<McpServerHealthResult> {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        bail!("invalid URL: must start with http:// or https://");
+    }
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("failed to create HTTP client")?;
+
+    let mut req = client
+        .get(url)
+        .header("Accept", "text/event-stream");
+
+    for (k, v) in headers {
+        req = req.header(k.as_str(), v.as_str());
+    }
+
+    match req.send() {
+        Ok(resp) if resp.status().is_success() || resp.status().is_redirection() => {
+            Ok(McpServerHealthResult {
+                status: "healthy".into(),
+                message: Some("SSE server reachable".into()),
+                auth_url: None,
+                needs_client_secret: None,
+                tools: Vec::new(),
+            })
+        }
+        Ok(resp) => {
+            bail!("SSE server returned {}", resp.status())
+        }
+        Err(e) if e.is_connect() => {
+            bail!("cannot connect to SSE server: {e}")
+        }
+        Err(e) if e.is_timeout() => {
+            bail!("SSE connection timed out")
+        }
+        Err(e) => {
+            bail!("SSE request failed: {e}")
+        }
+    }
+}
+
+// ── MCP tools/list ──
+
+fn build_tools_list_request() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {}
+    })
+}
+
+fn parse_tools_list_response(response_text: &str) -> Result<Vec<crate::config::ToolInfo>> {
+    let response: Value =
+        serde_json::from_str(response_text.trim()).context("invalid JSON response for tools/list")?;
+    if let Some(err) = response.get("error") {
+        let msg = err
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown error");
+        bail!("server returned error for tools/list: {msg}")
+    }
+    let tools = response
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(Value::as_array)
+        .context("unexpected tools/list response format")?;
+    tools
+        .iter()
+        .map(|t| {
+            Ok(crate::config::ToolInfo {
+                name: t
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .context("tool missing name")?
+                    .to_string(),
+                description: t.get("description").and_then(Value::as_str).map(String::from),
+                input_schema: t.get("inputSchema").cloned(),
+            })
+        })
+        .collect()
+}
+
+fn fetch_stdio_tools(
+    command: &str,
+    args: &[String],
+    env: &BTreeMap<String, String>,
+) -> Result<Vec<crate::config::ToolInfo>> {
+    let mut cmd = Command::new(command);
+    cmd.args(args);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("failed to start command: {command}"))?;
+
+    let mut stdin = child.stdin.take().context("failed to capture stdin")?;
+    let stdout = child.stdout.take().context("failed to capture stdout")?;
+
+    // Step 1: initialize
+    let init_line = serde_json::to_string(&build_initialize_request())? + "\n";
+    stdin.write_all(init_line.as_bytes())?;
+    stdin.flush()?;
+
+    let (tx, rx) = mpsc::channel();
+    let stdout_reader = std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(text) => {
+                    let trimmed = text.trim().to_string();
+                    if !trimmed.is_empty() {
+                        let _ = tx.send(Ok(trimmed));
+                        return;
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(e));
+                    return;
+                }
+            }
+        }
+        let _ = tx.send(Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "server closed stdout",
+        )));
+    });
+
+    let _init_response = rx
+        .recv_timeout(Duration::from_secs(10))
+        .context("initialize timed out")?
+        .context("failed to read initialize response")?;
+
+    // Step 2: tools/list
+    let tools_line = serde_json::to_string(&build_tools_list_request())? + "\n";
+    stdin.write_all(tools_line.as_bytes())?;
+    stdin.flush()?;
+    drop(stdin);
+
+    let tools_response = rx
+        .recv_timeout(Duration::from_secs(10))
+        .context("tools/list timed out")?
+        .context("failed to read tools/list response")?;
+
+    let _ = stdout_reader.join();
+    let _ = child.kill();
+    let _ = child.wait();
+
+    parse_tools_list_response(&tools_response)
+}
+
+fn fetch_http_tools(
+    url: &str,
+    headers: &BTreeMap<String, String>,
+) -> Result<Vec<crate::config::ToolInfo>> {
+    let tools_body = serde_json::to_string(&build_tools_list_request())?;
+    let mut req = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("failed to create HTTP client")?
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(tools_body);
+    for (k, v) in headers {
+        req = req.header(k.as_str(), v.as_str());
+    }
+    let resp = req.send().context("tools/list HTTP request failed")?;
+    let body = resp.text().context("failed to read tools/list response")?;
+    parse_tools_list_response(&body)
+}
+
+fn fetch_sse_tools(
+    url: &str,
+    headers: &BTreeMap<String, String>,
+) -> Result<Vec<crate::config::ToolInfo>> {
+    let base_url = url::Url::parse(url).context("invalid SSE URL")?;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .context("failed to create HTTP client")?;
+
+    // Step 1: GET SSE endpoint — read the first chunk for the endpoint URL
+    let mut req = client.get(url).header("Accept", "text/event-stream");
+    for (k, v) in headers {
+        req = req.header(k.as_str(), v.as_str());
+    }
+    let mut resp = req.send().context("failed to connect to SSE endpoint")?;
+    if !resp.status().is_success() {
+        bail!("SSE endpoint returned {}", resp.status());
+    }
+
+    use std::io::Read;
+    let mut buf = [0u8; 8192];
+    let n = resp.read(&mut buf).context("failed to read SSE handshake")?;
+    let sse_body = String::from_utf8_lossy(&buf[..n]);
+    let endpoint_url = discover_sse_endpoint(&sse_body, &base_url)
+        .context("SSE handshake did not contain an endpoint event")?;
+
+    // Step 2: Spawn reader thread to keep SSE connection alive and collect
+    // incoming events. The MCP SSE session is tied to this GET connection.
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let mut leftover = String::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            match resp.read(&mut buf) {
+                Ok(n) if n > 0 => {
+                    leftover.push_str(&String::from_utf8_lossy(&buf[..n]));
+                    // Emit complete lines; keep incomplete tail in leftover
+                    while let Some(nl) = leftover.find('\n') {
+                        let line = leftover[..nl].trim().to_string();
+                        leftover = leftover[nl + 1..].to_string();
+                        if let Some(data) = line.strip_prefix("data:") {
+                            let payload = data.trim().to_string();
+                            if !payload.is_empty() && tx.send(payload).is_err() {
+                                return;
+                            }
+                        }
+                    }
+                }
+                _ => return,
+            }
+        }
+    });
+
+    // Step 3: POST initialize
+    post_sse_json(&client, &endpoint_url, headers, &build_initialize_request())
+        .context("failed to POST initialize to SSE endpoint")?;
+    rx.recv_timeout(Duration::from_secs(10))
+        .context("no initialize response from SSE stream")?;
+
+    // Step 4: POST tools/list
+    post_sse_json(&client, &endpoint_url, headers, &build_tools_list_request())
+        .context("failed to POST tools/list to SSE endpoint")?;
+    let tools_raw = rx
+        .recv_timeout(Duration::from_secs(10))
+        .context("no tools/list response from SSE stream")?;
+
+    parse_tools_list_response(&tools_raw)
+}
+
+/// POST JSON-RPC request to an SSE message endpoint; 202 Accepted is normal
+fn post_sse_json(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    headers: &BTreeMap<String, String>,
+    body: &Value,
+) -> Result<()> {
+    let mut req = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(body)?);
+    for (k, v) in headers {
+        req = req.header(k.as_str(), v.as_str());
+    }
+    let resp = req.send()?;
+    let status = resp.status();
+    if !status.is_success() && status.as_u16() != 202 {
+        bail!("POST returned {}", status);
+    }
+    Ok(())
+}
+
+/// Parse SSE handshake text to find the `event: endpoint` → `data: <path>` pair
+fn discover_sse_endpoint(body: &str, base_url: &url::Url) -> Option<String> {
+    let mut current_event: Option<&str> = None;
+    for line in body.lines() {
+        if let Some(event_type) = line.strip_prefix("event:") {
+            current_event = Some(event_type.trim());
+        } else if let Some(data) = line.strip_prefix("data:") {
+            let data = data.trim();
+            if current_event == Some("endpoint") && !data.is_empty() {
+                return base_url.join(data).ok().map(|u| u.to_string());
+            }
+            current_event = None;
+        }
+    }
+    None
+}
+
 /// 对标 Zed resolve_start_failure → OAuth discovery
 fn try_oauth_discovery(
     url: &str,
@@ -604,7 +983,7 @@ fn try_oauth_discovery(
 
 // ── JSON Parser（对标 Zed parse_input / parse_http_input） ──
 
-fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig)> {
+fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig, Option<String>)> {
     let stripped: String = json_content
         .lines()
         .filter(|line| !line.trim().starts_with("///"))
@@ -618,11 +997,18 @@ fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig)> {
         "Expected exactly one server configuration"
     );
     let (id, entry) = value.into_iter().next().unwrap();
+    let display_name = entry.name.filter(|n| !n.is_empty());
     let transport = if let Some(url) = entry.url {
-        McpTransportConfig::Http {
-            url,
-            headers: entry.headers,
-            oauth: entry.oauth,
+        match entry.transport_type.as_deref() {
+            Some("sse") => McpTransportConfig::Sse {
+                url,
+                headers: entry.headers,
+            },
+            _ => McpTransportConfig::Http {
+                url,
+                headers: entry.headers,
+                oauth: entry.oauth,
+            },
         }
     } else {
         McpTransportConfig::Stdio {
@@ -633,5 +1019,5 @@ fn parse_mcp_json(json_content: &str) -> Result<(String, McpTransportConfig)> {
             env: entry.env,
         }
     };
-    Ok((id, transport))
+    Ok((id, transport, display_name))
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -390,6 +390,10 @@ export function checkMcpServerHealth(id: string) {
   return getRuntimeApi().checkMcpServerHealth(id);
 }
 
+export function listMcpTools(id: string) {
+  return getRuntimeApi().listMcpTools(id);
+}
+
 export function listSkills() {
   return getRuntimeApi().listSkills();
 }

--- a/web/src/api/browser.ts
+++ b/web/src/api/browser.ts
@@ -469,6 +469,7 @@ export const browserApi: RuntimeApi = {
   deleteMcpServer(_id: string) { return Promise.resolve([]); },
   toggleMcpServer(_id: string, _enabled: boolean) { return Promise.resolve([]); },
   checkMcpServerHealth(_id: string) { return Promise.resolve({ status: 'unknown' }); },
+  listMcpTools(_id: string) { return Promise.resolve([]); },
   listSkills() { return Promise.resolve({ global: [], project: [] }); },
   listProjectSkills(_workspacePath: string) { return Promise.resolve([]); },
   readSkill(_name: string, _source: string) { return Promise.resolve({ meta: { name: '', description: '', source: 'global', directoryPath: '', disableModelInvocation: false, loadWarnings: [] }, body: '' }); },

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -201,6 +201,7 @@ export interface RuntimeApi {
   deleteMcpServer(id: string): Promise<McpServerVm[]>;
   toggleMcpServer(id: string, enabled: boolean): Promise<McpServerVm[]>;
   checkMcpServerHealth(id: string): Promise<import('../types').McpServerHealthResult>;
+  listMcpTools(id: string): Promise<import('../types').ToolInfo[]>;
   listSkills(): Promise<SkillListVm>;
   listProjectSkills(workspacePath: string): Promise<import('../types').SkillMetaVm[]>;
   readSkill(name: string, source: string, workspacePath?: string | null): Promise<SkillContentVm>;

--- a/web/src/api/desktop.ts
+++ b/web/src/api/desktop.ts
@@ -332,6 +332,9 @@ export const desktopApi: RuntimeApi = {
   checkMcpServerHealth(id: string) {
     return invokeCommand('check_mcp_server_health', { id });
   },
+  listMcpTools(id: string) {
+    return invokeCommand('list_mcp_tools', { id });
+  },
   listSkills() {
     return invokeCommand('list_skills');
   },

--- a/web/src/components/EntitySection.tsx
+++ b/web/src/components/EntitySection.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react';
+import { AppCard } from '@/components/AppCard';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+export type EntitySectionTab = 'custom' | 'built-in';
+
+interface EntitySectionProps {
+  /** 当前激活的分段 */
+  tab: EntitySectionTab;
+  onTabChange: (tab: EntitySectionTab) => void;
+  /** 自定义分段标题 */
+  customLabel: string;
+  /** 内置分段标题 */
+  builtInLabel: string;
+  /** 头部右侧操作区（刷新/添加等） */
+  actions?: ReactNode;
+  /** 标题下方的工具栏（搜索/筛选） */
+  toolbar?: ReactNode;
+  /** 错误横幅，非空时展示 */
+  error?: ReactNode;
+  /** 底部区域（分页等） */
+  footer?: ReactNode;
+  /** 列表内容（卡片网格 + 空状态由消费方自行渲染） */
+  children: ReactNode;
+}
+
+/**
+ * 通用「自定义 / 内置」两段式列表骨架。
+ * 角色管理、MCP 管理、SKILL 管理等列表页共享此骨架，
+ * 后续任意一处 UI 优化（头部、搜索栏、滚动区）即可全局同步。
+ */
+export function EntitySection({
+  tab,
+  onTabChange,
+  customLabel,
+  builtInLabel,
+  actions,
+  toolbar,
+  error,
+  footer,
+  children,
+}: EntitySectionProps) {
+  return (
+    <AppCard className="flex h-full min-h-0 flex-col gap-0 py-0">
+      <CardHeader className="border-b px-4 pt-2 pb-1">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <Tabs value={tab} onValueChange={(value) => onTabChange(value as EntitySectionTab)}>
+            <TabsList variant="line">
+              <TabsTrigger value="custom">{customLabel}</TabsTrigger>
+              <TabsTrigger value="built-in">{builtInLabel}</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+        </div>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col p-0">
+        {toolbar ? (
+          <div className="flex flex-col gap-2 border-b px-4 py-1.5 lg:flex-row lg:items-center">
+            {toolbar}
+          </div>
+        ) : null}
+        {error ? (
+          <div className="m-4 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+        <ScrollArea className="min-h-0 flex-1">{children}</ScrollArea>
+        {footer}
+      </CardContent>
+    </AppCard>
+  );
+}

--- a/web/src/components/McpServerCard.tsx
+++ b/web/src/components/McpServerCard.tsx
@@ -1,0 +1,139 @@
+import { useTranslation } from 'react-i18next';
+import { Info, Loader2, Pencil, Stethoscope, Trash2, Wrench } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import type { McpServerVm } from '../types';
+
+interface McpHealthState {
+  status: string;
+  message?: string | null;
+}
+
+interface McpServerCardProps {
+  server: McpServerVm;
+  health?: McpHealthState;
+  isChecking: boolean;
+  isToolsFetching: boolean;
+  onToggle: (enabled: boolean) => void;
+  onHealthCheck: () => void;
+  onShowTools: () => void;
+  /** 仅自定义服务器提供：编辑入口 */
+  onEdit?: () => void;
+  /** 仅自定义服务器提供：删除入口 */
+  onDelete?: () => void;
+}
+
+export function McpServerCard({
+  server,
+  health,
+  isChecking,
+  isToolsFetching,
+  onToggle,
+  onHealthCheck,
+  onShowTools,
+  onEdit,
+  onDelete,
+}: McpServerCardProps) {
+  const { t } = useTranslation();
+  return (
+    <Card className={cn('group overflow-hidden border-border/50 transition-shadow hover:shadow-sm', !server.enabled && 'opacity-50')}>
+      <div className="flex items-center gap-3 border-b border-border/30 px-4 py-3">
+        <span
+          className={cn(
+            'size-2.5 shrink-0 rounded-full ring-1 ring-offset-1 ring-offset-background',
+            isChecking ? 'bg-yellow-400 ring-yellow-400/30 animate-pulse' :
+            health?.status === 'healthy' ? 'bg-green-500 ring-green-500/30' :
+            health?.status === 'auth_required' ? 'bg-yellow-500 ring-yellow-500/30' :
+            health?.status === 'unhealthy' ? 'bg-red-500 ring-red-500/30' :
+            'bg-gray-400 ring-gray-400/30',
+          )}
+          title={health?.message ?? ''}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-semibold">{server.name}</span>
+            <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-normal">{server.transport === 'stdio' ? 'Stdio' : server.transport === 'sse' ? 'SSE' : 'HTTP'}</Badge>
+            {server.helpMessage && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button type="button" className="inline-flex shrink-0 text-muted-foreground hover:text-foreground transition-colors" aria-label="帮助信息">
+                    <Info className="size-3.5" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent side="top" align="start" className="max-w-72 text-xs leading-relaxed whitespace-pre-wrap">
+                  {server.helpMessage}
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
+          <p className="truncate font-mono text-[11px] text-muted-foreground">{server.command ?? server.url ?? ''}</p>
+        </div>
+        <button
+          type="button" role="switch" aria-checked={server.enabled}
+          className={cn(
+            'relative h-5 w-9 shrink-0 rounded-full border transition-colors',
+            server.enabled ? 'border-primary bg-primary' : 'border-border/70 bg-muted-foreground/20',
+          )}
+          onClick={() => onToggle(!server.enabled)}
+        >
+          <span className={cn('block size-4 rounded-full bg-background shadow-sm transition-transform', server.enabled && 'translate-x-4')} />
+        </button>
+      </div>
+      <div className="flex items-center justify-between gap-1 px-2 py-1.5">
+        {health?.message ? (
+          <p className="truncate pl-3 text-[11px] text-muted-foreground">{health.message}</p>
+        ) : <span />}
+        <div className="flex shrink-0 items-center gap-1">
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button size="icon" variant="ghost" className="size-8" disabled={isChecking} onClick={onHealthCheck}>
+                  {isChecking ? <Loader2 className="size-3.5 animate-spin" /> : <Stethoscope className="size-3.5" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{t('contextManagement.mcp.diagnoseServer', 'MCP 服务诊断')}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button size="icon" variant="ghost" className="size-8" disabled={isToolsFetching} onClick={onShowTools}>
+                  {isToolsFetching ? <Loader2 className="size-3.5 animate-spin" /> : <Wrench className="size-3.5" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">工具列表</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          {onEdit && (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="icon" variant="ghost" className="size-8" onClick={onEdit}>
+                    <Pencil className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{t('contextManagement.mcp.editServer', 'Edit')}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {onDelete && (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="icon" variant="ghost" className="size-8 text-muted-foreground hover:text-destructive" onClick={onDelete}>
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{t('contextManagement.mcp.deleteServer', 'Delete')}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -284,6 +284,8 @@ const resources = {
         tabs: { mcp: "MCP 管理", skills: "SKILL 管理" },
         mcp: {
           addServer: "添加 MCP 服务器",
+          customSectionTitle: "自定义 MCP",
+          builtInSectionTitle: "内置 MCP",
           editServer: "配置 MCP 服务器",
           deleteServer: "删除 MCP 服务器",
           deleteDescription: "确定要删除 MCP 服务器 {{name}} 吗？",
@@ -1432,6 +1434,8 @@ const resources = {
         tabs: { mcp: "MCP", skills: "SKILLs" },
         mcp: {
           addServer: "Add MCP Server",
+          customSectionTitle: "Custom MCP",
+          builtInSectionTitle: "Built-in MCP",
           editServer: "Configure MCP Server",
           deleteServer: "Delete MCP Server",
           deleteDescription: "Delete MCP server {{name}}?",

--- a/web/src/pages/ContextManagementPage.tsx
+++ b/web/src/pages/ContextManagementPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
-import { Check, ChevronsUpDown, Edit, Eye, Info, Loader2, Pencil, Plus, RefreshCw, Search, Stethoscope, Trash2, Wrench } from 'lucide-react';
+import { Check, ChevronsUpDown, Edit, Eye, Loader2, Pencil, Plus, RefreshCw, Search, Trash2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import {
@@ -16,6 +16,8 @@ import type {
   McpServerVm, SkillListVm, SkillMetaVm, SkillContentVm, ToolInfo,
 } from '../types';
 import { AppCard } from '@/components/AppCard';
+import { EntitySection } from '@/components/EntitySection';
+import { McpServerCard } from '@/components/McpServerCard';
 import { EmptyState, Page, PageHeader } from '@/components/PageScaffold';
 import { Markdown } from '@/components/prompt-kit/markdown';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
@@ -77,6 +79,7 @@ export function ContextManagementPage() {
     };
   }, [mcpError]);
   const [mcpQuery, setMcpQuery] = useState('');
+  const [mcpListTab, setMcpListTab] = useState<'custom' | 'built-in'>('custom');
   const [mcpSheetOpen, setMcpSheetOpen] = useState(false);
   const [mcpEditTarget, setMcpEditTarget] = useState<McpServerVm | null>(null);
   const [mcpJsonContent, setMcpJsonContent] = useState('');
@@ -91,11 +94,16 @@ export function ContextManagementPage() {
   const [toolsError, setToolsError] = useState<string | null>(null);
   const [toolsFetchingId, setToolsFetchingId] = useState<string | null>(null);
 
+  const builtInMcpServers = useMemo(() => mcpServers.filter((s) => s.managed), [mcpServers]);
+  const customMcpServers = useMemo(() => mcpServers.filter((s) => !s.managed), [mcpServers]);
+  const currentSectionMcpServers = mcpListTab === 'built-in' ? builtInMcpServers : customMcpServers;
+
   const filteredMcpServers = useMemo(() => {
     const q = mcpQuery.trim().toLowerCase();
-    if (!q) return mcpServers;
-    return mcpServers.filter((s) => s.name.toLowerCase().includes(q) || (s.command ?? s.url ?? '').toLowerCase().includes(q));
-  }, [mcpServers, mcpQuery]);
+    const source = mcpListTab === 'built-in' ? builtInMcpServers : customMcpServers;
+    if (!q) return source;
+    return source.filter((s) => s.name.toLowerCase().includes(q) || (s.command ?? s.url ?? '').toLowerCase().includes(q));
+  }, [builtInMcpServers, customMcpServers, mcpListTab, mcpQuery]);
 
   // ── SKILL state ──
   const [skillList, setSkillList] = useState<SkillListVm | null>(null);
@@ -169,13 +177,13 @@ export function ContextManagementPage() {
     try {
       const servers = await listMcpServers();
       setMcpServers(servers);
-      // 对标 Zed maintain_servers: 加载后自动检查所有 enabled 服务器
+      // 健康状态由后端在启动时后台预探测并写入共享缓存，list 返回时已携带；
+      // 这里直接从 VM 回填，无需进入页面后再逐个触发网络检测。
+      const seed: Record<string, { status: string; message?: string | null }> = {};
       for (const s of servers) {
-        if (!s.enabled) continue;
-        checkMcpServerHealth(s.id)
-          .then((h) => setMcpHealth((prev) => ({ ...prev, [s.id]: h })))
-          .catch((err) => setMcpHealth((prev) => ({ ...prev, [s.id]: { status: 'unhealthy', message: displayAppError(t, err) } })));
+        if (s.healthStatus) seed[s.id] = { status: s.healthStatus, message: s.healthMessage };
       }
+      setMcpHealth(seed);
     } catch (err) { setMcpError(displayAppError(t, err)); }
     finally { setMcpLoading(false); }
   };
@@ -343,26 +351,22 @@ export function ContextManagementPage() {
       {/* ── Profiles Tab ── */}
       {activeTab === 'profiles' && (
       <div className="min-h-0 flex-1 p-5 xl:p-6">
-        <AppCard className="flex h-full min-h-0 flex-col gap-0 py-0">
-          <CardHeader className="border-b px-4 pt-2 pb-1">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <Tabs value={profileListTab} onValueChange={(value) => setProfileListTab(value as ProfileListTab)}>
-                <TabsList variant="line">
-                  <TabsTrigger value="custom">{t('contextManagement.customSectionTitle')}</TabsTrigger>
-                  <TabsTrigger value="built-in">{t('contextManagement.builtInSectionTitle')}</TabsTrigger>
-                </TabsList>
-              </Tabs>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button variant="outline" disabled={loading} onClick={() => void refresh()}>
-                  <RefreshCw className={cn(loading && 'animate-spin')} />
-                  {t('common.refresh')}
-                </Button>
-                <Button onClick={() => openSheet('create')}><Plus />{t('contextManagement.addProfile')}</Button>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="flex min-h-0 flex-1 flex-col p-0">
-            <div className="flex flex-col gap-2 border-b px-4 py-1.5 lg:flex-row lg:items-center">
+        <EntitySection
+          tab={profileListTab}
+          onTabChange={(value) => setProfileListTab(value)}
+          customLabel={t('contextManagement.customSectionTitle')}
+          builtInLabel={t('contextManagement.builtInSectionTitle')}
+          actions={
+            <>
+              <Button variant="outline" disabled={loading} onClick={() => void refresh()}>
+                <RefreshCw className={cn(loading && 'animate-spin')} />
+                {t('common.refresh')}
+              </Button>
+              <Button onClick={() => openSheet('create')}><Plus />{t('contextManagement.addProfile')}</Button>
+            </>
+          }
+          toolbar={
+            <>
               <div className="relative min-w-[240px] flex-1">
                 <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
@@ -382,39 +386,11 @@ export function ContextManagementPage() {
                   </SelectContent>
                 </Select>
               ) : null}
-            </div>
-            {error ? <div className="m-4 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div> : null}
-            <ScrollArea className="min-h-0 flex-1">
-              {loading && !vm ? <EmptyState>{t('common.loading')}</EmptyState> : null}
-              {vm && profileListTab === 'built-in' ? (
-                <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-3">
-                  {builtInProfiles.map((profile) => (
-                    <BuiltInProfileCard
-                      key={`${profile.scope}:${profile.id}`}
-                      profile={profile}
-                      onView={() => openSheet('view', profile)}
-                      onEdit={() => openSheet('edit', profile)}
-                    />
-                  ))}
-                </div>
-              ) : null}
-              {vm && profileListTab === 'custom' ? (
-                <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-3">
-                  {pagedCustomProfiles.map((profile) => (
-                    <CustomProfileCard
-                      key={`${profile.scope}:${profile.id}`}
-                      profile={profile}
-                      onView={() => openSheet('view', profile)}
-                      onEdit={() => openSheet('edit', profile)}
-                      onDelete={() => openDeleteDialog(profile)}
-                    />
-                  ))}
-                </div>
-              ) : null}
-              {vm && profileListTab === 'built-in' && builtInProfiles.length === 0 ? <div className="p-5"><EmptyState>{t('contextManagement.emptyProfiles')}</EmptyState></div> : null}
-              {vm && profileListTab === 'custom' && customProfiles.length === 0 ? <div className="p-5"><EmptyState>{t('contextManagement.emptyProfiles')}</EmptyState></div> : null}
-            </ScrollArea>
-            {profileListTab === 'custom' && customProfiles.length > 0 ? (
+            </>
+          }
+          error={error}
+          footer={
+            profileListTab === 'custom' && customProfiles.length > 0 ? (
               <div className="flex flex-wrap items-center justify-between gap-3 border-t px-4 py-3 text-sm text-muted-foreground">
                 <span>{t('contextManagement.customProfilesPageRange', {
                   start: customProfiles.length ? safePageIndex * pageSize + 1 : 0,
@@ -427,9 +403,38 @@ export function ContextManagementPage() {
                   <ProfilePagination pageIndex={safePageIndex} pageCount={pageCount} onPageChange={setPageIndex} />
                 </div>
               </div>
-            ) : null}
-          </CardContent>
-        </AppCard>
+            ) : null
+          }
+        >
+          {loading && !vm ? <EmptyState>{t('common.loading')}</EmptyState> : null}
+          {vm && profileListTab === 'built-in' ? (
+            <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-3">
+              {builtInProfiles.map((profile) => (
+                <BuiltInProfileCard
+                  key={`${profile.scope}:${profile.id}`}
+                  profile={profile}
+                  onView={() => openSheet('view', profile)}
+                  onEdit={() => openSheet('edit', profile)}
+                />
+              ))}
+            </div>
+          ) : null}
+          {vm && profileListTab === 'custom' ? (
+            <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-3">
+              {pagedCustomProfiles.map((profile) => (
+                <CustomProfileCard
+                  key={`${profile.scope}:${profile.id}`}
+                  profile={profile}
+                  onView={() => openSheet('view', profile)}
+                  onEdit={() => openSheet('edit', profile)}
+                  onDelete={() => openDeleteDialog(profile)}
+                />
+              ))}
+            </div>
+          ) : null}
+          {vm && profileListTab === 'built-in' && builtInProfiles.length === 0 ? <div className="p-5"><EmptyState>{t('contextManagement.emptyProfiles')}</EmptyState></div> : null}
+          {vm && profileListTab === 'custom' && customProfiles.length === 0 ? <div className="p-5"><EmptyState>{t('contextManagement.emptyProfiles')}</EmptyState></div> : null}
+        </EntitySection>
       </div>
       )}
       <ProfileSheet
@@ -485,169 +490,91 @@ export function ContextManagementPage() {
       {/* ── MCP Tab Content ── */}
       {activeTab === 'mcp' && (
         <div className="min-h-0 flex-1 p-5 xl:p-6">
-          <AppCard className="flex h-full min-h-0 flex-col gap-0 py-0">
-            <CardContent className="flex min-h-0 flex-1 flex-col gap-3 p-4">
-          <div className="flex flex-wrap items-center justify-between gap-2 shrink-0">
-            <div className="relative min-w-[200px] flex-1 max-w-sm">
-              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input className="h-8 pl-8 text-xs" placeholder="搜索 MCP 服务器..." value={mcpQuery} onChange={(e) => setMcpQuery(e.target.value)} />
+          <EntitySection
+            tab={mcpListTab}
+            onTabChange={setMcpListTab}
+            customLabel={t('contextManagement.mcp.customSectionTitle', '自定义 MCP')}
+            builtInLabel={t('contextManagement.mcp.builtInSectionTitle', '内置 MCP')}
+            actions={
+              <>
+                <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <span className="flex items-center gap-0.5"><span className="size-1.5 rounded-full bg-green-500" />{mcpServers.filter((s) => mcpHealth[s.id]?.status === 'healthy').length}</span>
+                  <span className="flex items-center gap-0.5"><span className="size-1.5 rounded-full bg-yellow-500" />{mcpServers.filter((s) => mcpHealth[s.id]?.status === 'auth_required').length}</span>
+                  <span className="flex items-center gap-0.5"><span className="size-1.5 rounded-full bg-red-500" />{mcpServers.filter((s) => mcpHealth[s.id]?.status === 'unhealthy').length}</span>
+                </span>
+                <Button variant="outline" size="sm" disabled={mcpLoading} onClick={() => void refreshMcp()}><RefreshCw className={cn('size-4', mcpLoading && 'animate-spin')} /></Button>
+                <Button size="sm" onClick={() => { setMcpEditTarget(null); setMcpJsonContent(MCP_STDIO_TEMPLATE); setMcpTransportTab('stdio'); setMcpSheetOpen(true); }}><Plus className="size-4" />{t('contextManagement.mcp.addServer', '添加')}</Button>
+              </>
+            }
+            toolbar={
+              <div className="relative min-w-[240px] flex-1">
+                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input className="pl-9" placeholder={t('contextManagement.searchPlaceholder', '搜索…')} value={mcpQuery} onChange={(e) => setMcpQuery(e.target.value)} />
+              </div>
+            }
+            error={mcpError ? (
+              <div className="flex items-start gap-2">
+                <span className="flex-1">{mcpError}</span>
+                <button type="button" onClick={() => setMcpError(null)} className="shrink-0 rounded-sm opacity-70 transition-opacity hover:opacity-100" aria-label="Dismiss">✕</button>
+              </div>
+            ) : null}
+          >
+            {mcpLoading && mcpServers.length === 0 ? <div className="p-5"><EmptyState>{t('common.loading')}</EmptyState></div> : null}
+            <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-3">
+              {filteredMcpServers.map((s) => (
+                <McpServerCard
+                  key={s.id}
+                  server={s}
+                  health={mcpHealth[s.id]}
+                  isChecking={mcpCheckTarget === s.id}
+                  isToolsFetching={toolsFetchingId === s.id}
+                  onToggle={async (newEnabled) => {
+                    try { setMcpServers(await toggleMcpServer(s.id, newEnabled)); } catch (err) { setMcpError(displayAppError(t, err)); return; }
+                    if (newEnabled) {
+                      setMcpCheckTarget(s.id);
+                      try {
+                        const hh = await checkMcpServerHealth(s.id);
+                        setMcpHealth((prev) => ({ ...prev, [s.id]: hh }));
+                      } catch (err: unknown) {
+                        setMcpHealth((prev) => ({ ...prev, [s.id]: { status: 'unhealthy', message: displayAppError(t, err) } }));
+                      } finally { setMcpCheckTarget(null); }
+                    } else {
+                      setMcpHealth((prev) => { const n = { ...prev }; delete n[s.id]; return n; });
+                    }
+                  }}
+                  onHealthCheck={async () => {
+                    setMcpCheckTarget(s.id);
+                    try {
+                      const result = await checkMcpServerHealth(s.id);
+                      setMcpHealth((prev) => ({ ...prev, [s.id]: result }));
+                    } catch (err: unknown) {
+                      setMcpHealth((prev) => ({ ...prev, [s.id]: { status: 'unhealthy', message: displayAppError(t, err) } }));
+                    } finally { setMcpCheckTarget(null); }
+                  }}
+                  onShowTools={async () => {
+                    if (toolsFetchingId) return;
+                    setToolsFetchingId(s.id);
+                    try {
+                      const tools = await listMcpTools(s.id);
+                      setToolsList(tools);
+                      setToolsError(null);
+                      setToolsSheetServer(s);
+                    } catch (err: unknown) {
+                      setToolsError(displayAppError(t, err));
+                      setToolsList(null);
+                      setToolsSheetServer(s);
+                    } finally {
+                      setToolsFetchingId(null);
+                    }
+                  }}
+                  onEdit={s.managed ? undefined : () => { setMcpEditTarget(s); setMcpJsonContent(mcpServerToJson(s)); setMcpTransportTab(s.transport as 'stdio' | 'http' | 'sse'); setMcpSheetOpen(true); }}
+                  onDelete={s.managed ? undefined : () => setMcpDeleteTarget(s)}
+                />
+              ))}
             </div>
-            <div className="flex items-center gap-2">
-              <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                <span className="flex items-center gap-0.5"><span className="size-1.5 rounded-full bg-green-500" />{mcpServers.filter((s) => mcpHealth[s.id]?.status === 'healthy').length}</span>
-                <span className="flex items-center gap-0.5"><span className="size-1.5 rounded-full bg-yellow-500" />{mcpServers.filter((s) => mcpHealth[s.id]?.status === 'auth_required').length}</span>
-                <span className="flex items-center gap-0.5"><span className="size-1.5 rounded-full bg-red-500" />{mcpServers.filter((s) => mcpHealth[s.id]?.status === 'unhealthy').length}</span>
-              </span>
-              <Button variant="outline" size="sm" disabled={mcpLoading} onClick={() => void refreshMcp()}><RefreshCw className={cn('size-4', mcpLoading && 'animate-spin')} /></Button>
-              <Button size="sm" onClick={() => { setMcpEditTarget(null); setMcpJsonContent(MCP_STDIO_TEMPLATE); setMcpTransportTab('stdio'); setMcpSheetOpen(true); }}><Plus className="size-4" />{t('contextManagement.mcp.addServer', '添加')}</Button>
-            </div>
-          </div>
-          {mcpError ? <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"><span className="flex-1">{mcpError}</span><button type="button" onClick={() => setMcpError(null)} className="shrink-0 rounded-sm opacity-70 transition-opacity hover:opacity-100" aria-label="Dismiss">✕</button></div> : null}
-          <ScrollArea className="min-h-0 flex-1">
-            {mcpLoading && mcpServers.length === 0 ? <EmptyState>{t('common.loading')}</EmptyState> : null}
-            {!mcpLoading && mcpServers.length === 0 ? <EmptyState>{t('contextManagement.mcp.emptyServers', '暂无 MCP 服务器')}</EmptyState> : null}
-            {!mcpLoading && mcpServers.length > 0 && filteredMcpServers.length === 0 ? <EmptyState>无匹配结果</EmptyState> : null}
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-              {filteredMcpServers.map((s) => {
-                const h = mcpHealth[s.id];
-                const isChecking = mcpCheckTarget === s.id;
-                return (
-                <Card key={s.id} className={cn('group overflow-hidden border-border/50 transition-shadow hover:shadow-sm', !s.enabled && 'opacity-50')}>
-                  <div className="flex items-center gap-3 border-b border-border/30 px-4 py-3">
-                    <span className={cn(
-                      'size-2.5 shrink-0 rounded-full ring-1 ring-offset-1 ring-offset-background',
-                      isChecking ? 'bg-yellow-400 ring-yellow-400/30 animate-pulse' :
-                      h?.status === 'healthy' ? 'bg-green-500 ring-green-500/30' :
-                      h?.status === 'auth_required' ? 'bg-yellow-500 ring-yellow-500/30' :
-                      h?.status === 'unhealthy' ? 'bg-red-500 ring-red-500/30' :
-                      'bg-gray-400 ring-gray-400/30'
-                    )} title={h?.message ?? ''} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate text-sm font-semibold">{s.name}</span>
-                        {s.managed && <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] font-normal text-muted-foreground">内置</Badge>}
-                        <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-normal">{s.transport === 'stdio' ? 'Stdio' : s.transport === 'sse' ? 'SSE' : 'HTTP'}</Badge>
-                        {s.helpMessage && (
-                          <Popover>
-                            <PopoverTrigger asChild>
-                              <button type="button" className="inline-flex shrink-0 text-muted-foreground hover:text-foreground transition-colors" aria-label="帮助信息">
-                                <Info className="size-3.5" />
-                              </button>
-                            </PopoverTrigger>
-                            <PopoverContent side="top" align="start" className="max-w-72 text-xs leading-relaxed whitespace-pre-wrap">
-                              {s.helpMessage}
-                            </PopoverContent>
-                          </Popover>
-                        )}
-                      </div>
-                      <p className="truncate font-mono text-[11px] text-muted-foreground">{s.command ?? s.url ?? ''}</p>
-                    </div>
-                    <button
-                      type="button" role="switch" aria-checked={s.enabled}
-                      className={cn(
-                        'relative h-5 w-9 shrink-0 rounded-full border transition-colors',
-                        s.enabled ? 'border-primary bg-primary' : 'border-border/70 bg-muted-foreground/20',
-                      )}
-                      onClick={async () => {
-                        const newEnabled = !s.enabled;
-                        try { setMcpServers(await toggleMcpServer(s.id, newEnabled)); } catch (err) { setMcpError(displayAppError(t, err)); return; }
-                        if (newEnabled) {
-                          setMcpCheckTarget(s.id);
-                          try {
-                            const hh = await checkMcpServerHealth(s.id);
-                            setMcpHealth((prev) => ({ ...prev, [s.id]: hh }));
-                          } catch (err: unknown) {
-                            setMcpHealth((prev) => ({ ...prev, [s.id]: { status: 'unhealthy', message: displayAppError(t, err) } }));
-                          } finally { setMcpCheckTarget(null); }
-                        } else {
-                          setMcpHealth((prev) => { const n = { ...prev }; delete n[s.id]; return n; });
-                        }
-                      }}
-                    >
-                      <span className={cn('block size-4 rounded-full bg-background shadow-sm transition-transform', s.enabled && 'translate-x-4')} />
-                    </button>
-                  </div>
-                  <div className="flex items-center justify-between gap-1 px-2 py-1.5">
-                    {h?.message && (
-                      <p className="truncate pl-3 text-[11px] text-muted-foreground">{h.message}</p>
-                    )}
-                    {!h?.message && <span />}
-                    <div className="flex shrink-0 items-center gap-1">
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button size="icon" variant="ghost" className="size-8" disabled={isChecking} onClick={async () => {
-                              setMcpCheckTarget(s.id);
-                              try {
-                                const result = await checkMcpServerHealth(s.id);
-                                setMcpHealth((prev) => ({ ...prev, [s.id]: result }));
-                              } catch (err: unknown) {
-                                setMcpHealth((prev) => ({ ...prev, [s.id]: { status: 'unhealthy', message: displayAppError(t, err) } }));
-                              } finally { setMcpCheckTarget(null); }
-                            }}>
-                              {isChecking ? <Loader2 className="size-3.5 animate-spin" /> : <Stethoscope className="size-3.5" />}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="top">{t('contextManagement.mcp.diagnoseServer', 'MCP 服务诊断')}</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button size="icon" variant="ghost" className="size-8" disabled={toolsFetchingId === s.id} onClick={async () => {
-                              if (toolsFetchingId) return;
-                              setToolsFetchingId(s.id);
-                              try {
-                                const tools = await listMcpTools(s.id);
-                                setToolsList(tools);
-                                setToolsError(null);
-                                setToolsSheetServer(s);
-                              } catch (err: unknown) {
-                                setToolsError(displayAppError(t, err));
-                                setToolsList(null);
-                                setToolsSheetServer(s);
-                              } finally {
-                                setToolsFetchingId(null);
-                              }
-                            }}>
-                              {toolsFetchingId === s.id ? <Loader2 className="size-3.5 animate-spin" /> : <Wrench className="size-3.5" />}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="top">工具列表</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      {!s.managed && (
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button size="icon" variant="ghost" className="size-8" onClick={() => { setMcpEditTarget(s); setMcpJsonContent(mcpServerToJson(s)); setMcpTransportTab(s.transport as 'stdio' | 'http' | 'sse'); setMcpSheetOpen(true); }}>
-                              <Pencil className="size-3.5" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="top">{t('contextManagement.mcp.editServer', 'Edit')}</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      )}
-                      {!s.managed && (
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button size="icon" variant="ghost" className="size-8 text-muted-foreground hover:text-destructive" onClick={() => setMcpDeleteTarget(s)}>
-                              <Trash2 className="size-3.5" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="top">{t('contextManagement.mcp.deleteServer', 'Delete')}</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      )}
-                    </div>
-                  </div>
-                </Card>
-              )})}
-            </div>
-            </ScrollArea>
-          </CardContent>
-        </AppCard>
+            {!mcpLoading && currentSectionMcpServers.length === 0 ? <div className="p-5"><EmptyState>{t('contextManagement.mcp.emptyServers', '暂无 MCP 服务器')}</EmptyState></div> : null}
+            {!mcpLoading && currentSectionMcpServers.length > 0 && filteredMcpServers.length === 0 ? <div className="p-5"><EmptyState>{t('common.noResults', '无匹配结果')}</EmptyState></div> : null}
+          </EntitySection>
         </div>
       )}
 

--- a/web/src/pages/ContextManagementPage.tsx
+++ b/web/src/pages/ContextManagementPage.tsx
@@ -554,16 +554,19 @@ export function ContextManagementPage() {
                   onShowTools={async () => {
                     if (toolsFetchingId) return;
                     setToolsFetchingId(s.id);
+                    setToolsSheetServer(s);
+                    setToolsList(null);
+                    setToolsError(null);
+                    setToolsLoading(true);
                     try {
                       const tools = await listMcpTools(s.id);
                       setToolsList(tools);
                       setToolsError(null);
-                      setToolsSheetServer(s);
                     } catch (err: unknown) {
                       setToolsError(displayAppError(t, err));
                       setToolsList(null);
-                      setToolsSheetServer(s);
                     } finally {
+                      setToolsLoading(false);
                       setToolsFetchingId(null);
                     }
                   }}
@@ -734,7 +737,7 @@ export function ContextManagementPage() {
       </AlertDialog>
 
       {/* ── MCP Tools Sheet ── */}
-      <Sheet open={Boolean(toolsSheetServer)} onOpenChange={(open) => { if (!open) { setToolsSheetServer(null); setToolsList(null); setToolsError(null); } }}>
+      <Sheet open={Boolean(toolsSheetServer)} onOpenChange={(open) => { if (!open) { setToolsSheetServer(null); setToolsList(null); setToolsError(null); setToolsLoading(false); } }}>
         <SheetContent className="gap-0 overflow-hidden" resizeStorageKey="context-management/tools-sheet" defaultSize={560} minSize={420} maxSize={800}>
           <SheetHeader className="border-b px-5 py-4">
             <SheetTitle className="flex items-center gap-2">

--- a/web/src/pages/ContextManagementPage.tsx
+++ b/web/src/pages/ContextManagementPage.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
-import { Check, ChevronsUpDown, Edit, Eye, Loader2, Pencil, Plus, RefreshCw, Search, Stethoscope, Trash2 } from 'lucide-react';
+import { Check, ChevronsUpDown, Edit, Eye, Loader2, Pencil, Plus, RefreshCw, Search, Stethoscope, Trash2, Wrench } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import {
   createProfile, deleteProfile, getProfiles, updateProfile,
   listMcpServers, addMcpServer, updateMcpServer, deleteMcpServer,
-  toggleMcpServer, checkMcpServerHealth,
+  toggleMcpServer, checkMcpServerHealth, listMcpTools,
   listSkills, listProjectSkills, readSkill, writeSkill, deleteSkill,
   getConversationSidebar,
 } from '../api';
 import { displayAppError } from '../i18n';
 import type {
   AppErrorVm, ProfileInput, ProfileListVm, ProfileScope, ProfileVm,
-  McpServerVm, SkillListVm, SkillMetaVm, SkillContentVm,
+  McpServerVm, SkillListVm, SkillMetaVm, SkillContentVm, ToolInfo,
 } from '../types';
 import { AppCard } from '@/components/AppCard';
 import { EmptyState, Page, PageHeader } from '@/components/PageScaffold';
@@ -80,11 +80,16 @@ export function ContextManagementPage() {
   const [mcpSheetOpen, setMcpSheetOpen] = useState(false);
   const [mcpEditTarget, setMcpEditTarget] = useState<McpServerVm | null>(null);
   const [mcpJsonContent, setMcpJsonContent] = useState('');
-  const [mcpTransportTab, setMcpTransportTab] = useState<'stdio' | 'http'>('stdio');
+  const [mcpTransportTab, setMcpTransportTab] = useState<'stdio' | 'http' | 'sse'>('stdio');
   const [mcpSaving, setMcpSaving] = useState(false);
   const [mcpDeleteTarget, setMcpDeleteTarget] = useState<McpServerVm | null>(null);
   const [mcpCheckTarget, setMcpCheckTarget] = useState<string | null>(null);
   const [mcpHealth, setMcpHealth] = useState<Record<string, { status: string; message?: string | null }>>({});
+  const [toolsSheetServer, setToolsSheetServer] = useState<McpServerVm | null>(null);
+  const [toolsList, setToolsList] = useState<ToolInfo[] | null>(null);
+  const [toolsLoading, setToolsLoading] = useState(false);
+  const [toolsError, setToolsError] = useState<string | null>(null);
+  const [toolsFetchingId, setToolsFetchingId] = useState<string | null>(null);
 
   const filteredMcpServers = useMemo(() => {
     const q = mcpQuery.trim().toLowerCase();
@@ -520,7 +525,8 @@ export function ContextManagementPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <span className="truncate text-sm font-semibold">{s.name}</span>
-                        <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-normal">{s.transport === 'stdio' ? 'Stdio' : 'HTTP'}</Badge>
+                        {s.managed && <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] font-normal text-muted-foreground">内置</Badge>}
+                        <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-normal">{s.transport === 'stdio' ? 'Stdio' : s.transport === 'sse' ? 'SSE' : 'HTTP'}</Badge>
                       </div>
                       <p className="truncate font-mono text-[11px] text-muted-foreground">{s.command ?? s.url ?? ''}</p>
                     </div>
@@ -576,13 +582,41 @@ export function ContextManagementPage() {
                       <TooltipProvider delayDuration={300}>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <Button size="icon" variant="ghost" className="size-8" onClick={() => { setMcpEditTarget(s); setMcpJsonContent(mcpServerToJson(s)); setMcpTransportTab(s.transport === 'stdio' ? 'stdio' : 'http'); setMcpSheetOpen(true); }}>
+                            <Button size="icon" variant="ghost" className="size-8" disabled={toolsFetchingId === s.id} onClick={async () => {
+                              if (toolsFetchingId) return;
+                              setToolsFetchingId(s.id);
+                              try {
+                                const tools = await listMcpTools(s.id);
+                                setToolsList(tools);
+                                setToolsError(null);
+                                setToolsSheetServer(s);
+                              } catch (err: unknown) {
+                                setToolsError(displayAppError(t, err));
+                                setToolsList(null);
+                                setToolsSheetServer(s);
+                              } finally {
+                                setToolsFetchingId(null);
+                              }
+                            }}>
+                              {toolsFetchingId === s.id ? <Loader2 className="size-3.5 animate-spin" /> : <Wrench className="size-3.5" />}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">工具列表</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      {!s.managed && (
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button size="icon" variant="ghost" className="size-8" onClick={() => { setMcpEditTarget(s); setMcpJsonContent(mcpServerToJson(s)); setMcpTransportTab(s.transport as 'stdio' | 'http' | 'sse'); setMcpSheetOpen(true); }}>
                               <Pencil className="size-3.5" />
                             </Button>
                           </TooltipTrigger>
                           <TooltipContent side="top">{t('contextManagement.mcp.editServer', 'Edit')}</TooltipContent>
                         </Tooltip>
                       </TooltipProvider>
+                      )}
+                      {!s.managed && (
                       <TooltipProvider delayDuration={300}>
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -593,6 +627,7 @@ export function ContextManagementPage() {
                           <TooltipContent side="top">{t('contextManagement.mcp.deleteServer', 'Delete')}</TooltipContent>
                         </Tooltip>
                       </TooltipProvider>
+                      )}
                     </div>
                   </div>
                 </Card>
@@ -719,6 +754,7 @@ export function ContextManagementPage() {
             <div className="flex gap-1 border-b">
               <button type="button" className={cn('px-3 py-2 text-sm font-medium border-b-2 transition-colors', mcpTransportTab === 'stdio' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground')} onClick={() => { setMcpTransportTab('stdio'); setMcpJsonContent(MCP_STDIO_TEMPLATE); }}>{t('contextManagement.mcp.localTab', '本地 (Stdio)')}</button>
               <button type="button" className={cn('px-3 py-2 text-sm font-medium border-b-2 transition-colors', mcpTransportTab === 'http' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground')} onClick={() => { setMcpTransportTab('http'); setMcpJsonContent(MCP_HTTP_TEMPLATE); }}>{t('contextManagement.mcp.remoteTab', '远程 (HTTP)')}</button>
+              <button type="button" className={cn('px-3 py-2 text-sm font-medium border-b-2 transition-colors', mcpTransportTab === 'sse' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground')} onClick={() => { setMcpTransportTab('sse'); setMcpJsonContent(MCP_SSE_TEMPLATE); }}>{t('contextManagement.mcp.sseTab', '远程 (SSE)')}</button>
             </div>
             ) : null}
             <textarea
@@ -757,6 +793,57 @@ export function ContextManagementPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* ── MCP Tools Sheet ── */}
+      <Sheet open={Boolean(toolsSheetServer)} onOpenChange={(open) => { if (!open) { setToolsSheetServer(null); setToolsList(null); setToolsError(null); } }}>
+        <SheetContent className="gap-0 overflow-hidden" resizeStorageKey="context-management/tools-sheet" defaultSize={560} minSize={420} maxSize={800}>
+          <SheetHeader className="border-b px-5 py-4">
+            <SheetTitle className="flex items-center gap-2">
+              <span className="truncate">{toolsSheetServer?.name ?? ''}</span>
+              <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-normal">{toolsSheetServer?.transport === 'stdio' ? 'Stdio' : toolsSheetServer?.transport === 'sse' ? 'SSE' : 'HTTP'}</Badge>
+            </SheetTitle>
+          </SheetHeader>
+          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4">
+            {toolsLoading ? (
+              <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                正在获取工具列表…
+              </div>
+            ) : toolsError ? (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{toolsError}</div>
+            ) : toolsList && toolsList.length === 0 ? (
+              <div className="py-12 text-center text-sm text-muted-foreground">该服务器未提供任何工具</div>
+            ) : toolsList ? (
+              <>
+                <p className="text-xs text-muted-foreground">共 {toolsList.length} 个工具</p>
+                <div className="space-y-2">
+                  {toolsList.map((tool) => (
+                    <div key={tool.name} className="rounded-lg border border-border/50 bg-card/40 px-4 py-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium">{tool.name}</p>
+                          {tool.description && (
+                            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{tool.description}</p>
+                          )}
+                        </div>
+                      </div>
+                      {tool.inputSchema && typeof tool.inputSchema === 'object' && Object.keys(tool.inputSchema as Record<string, unknown>).length > 0 && (
+                        <details className="mt-2">
+                          <summary className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground">参数 Schema</summary>
+                          <pre className="mt-1.5 overflow-x-auto rounded-md bg-muted/50 px-3 py-2 font-mono text-[11px] leading-relaxed">{JSON.stringify(tool.inputSchema, null, 2)}</pre>
+                        </details>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : null}
+          </div>
+          <SheetFooter className="border-t px-5 py-4">
+            <Button variant="outline" onClick={() => { setToolsSheetServer(null); setToolsList(null); setToolsError(null); }}>关闭</Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
 
       {/* ── SKILL Sheet ── */}
       <Sheet open={skillSheetMode !== null} onOpenChange={(open) => { if (!open) setSkillSheetMode(null); }}>
@@ -1321,7 +1408,38 @@ const MCP_HTTP_TEMPLATE = `{
   }
 }`;
 
+const MCP_SSE_TEMPLATE = `{
+  /// Configure an MCP server using Server-Sent Events (SSE) transport
+  ///
+  /// The name of your SSE MCP server
+  "some-sse-server": {
+    /// The transport type — must be "sse"
+    "type": "sse",
+    /// The URL of the SSE MCP server endpoint
+    "url": "https://example.com/mcp/sse",
+    /// Any headers to send along
+    "headers": {
+      // "Authorization": "Bearer <token>"
+    }
+  }
+}`;
+
 function mcpServerToJson(s: McpServerVm): string {
+  if (s.transport === 'sse') {
+    const headers = s.headers?.length
+      ? s.headers.map((h) => `"${h.key}": "${h.value}"`).join(',\n      ')
+      : '// "Authorization": "Bearer <token>"';
+    return `{
+  /// Configure an MCP server using Server-Sent Events (SSE) transport
+  "${s.name}": {
+    "type": "sse",
+    "url": "${s.url ?? ''}",
+    "headers": {
+      ${headers}
+    }
+  }
+}`;
+  }
   if (s.transport === 'http') {
     const headers = s.headers?.length
       ? s.headers.map((h) => `"${h.key}": "${h.value}"`).join(',\n      ')

--- a/web/src/pages/ContextManagementPage.tsx
+++ b/web/src/pages/ContextManagementPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
-import { Check, ChevronsUpDown, Edit, Eye, Loader2, Pencil, Plus, RefreshCw, Search, Stethoscope, Trash2, Wrench } from 'lucide-react';
+import { Check, ChevronsUpDown, Edit, Eye, Info, Loader2, Pencil, Plus, RefreshCw, Search, Stethoscope, Trash2, Wrench } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import {
@@ -527,6 +527,18 @@ export function ContextManagementPage() {
                         <span className="truncate text-sm font-semibold">{s.name}</span>
                         {s.managed && <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] font-normal text-muted-foreground">内置</Badge>}
                         <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-normal">{s.transport === 'stdio' ? 'Stdio' : s.transport === 'sse' ? 'SSE' : 'HTTP'}</Badge>
+                        {s.helpMessage && (
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button type="button" className="inline-flex shrink-0 text-muted-foreground hover:text-foreground transition-colors" aria-label="帮助信息">
+                                <Info className="size-3.5" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent side="top" align="start" className="max-w-72 text-xs leading-relaxed whitespace-pre-wrap">
+                              {s.helpMessage}
+                            </PopoverContent>
+                          </Popover>
+                        )}
                       </div>
                       <p className="truncate font-mono text-[11px] text-muted-foreground">{s.command ?? s.url ?? ''}</p>
                     </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1099,6 +1099,7 @@ export interface McpServerVm {
   url?: string | null;
   headers?: AgentEnvEntryVm[] | null;
   managed: boolean;
+  helpMessage?: string | null;
   healthStatus?: 'healthy' | 'unhealthy' | 'auth_required' | 'stopped' | 'checking' | 'unknown' | null;
   healthMessage?: string | null;
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1092,12 +1092,13 @@ export interface McpServerVm {
   id: string;
   name: string;
   enabled: boolean;
-  transport: 'stdio' | 'http';
+  transport: 'stdio' | 'http' | 'sse';
   command?: string | null;
   args?: string[] | null;
   env?: AgentEnvEntryVm[] | null;
   url?: string | null;
   headers?: AgentEnvEntryVm[] | null;
+  managed: boolean;
   healthStatus?: 'healthy' | 'unhealthy' | 'auth_required' | 'stopped' | 'checking' | 'unknown' | null;
   healthMessage?: string | null;
 }


### PR DESCRIPTION
… tools/list support

- Add SSE transport variant to McpTransportConfig with endpoint discovery
- Add managed flag to McpServerConfig to prevent user deletion/editing
- Auto-inject builtin MCP servers from channel config on startup (wb only)
- Implement tools/list protocol for stdio, HTTP, and SSE transports
- SSE tools uses concurrent GET+PIPE to keep session alive during POST
- Add tools detail Sheet UI with per-tool name, description, and inputSchema
- Hide delete/edit buttons for managed servers, show "builtin" badge
- Fix SSE reader to buffer partial lines across TCP frame boundaries