### PR TITLE
fix(metrics): 上报隐藏 UUID 字段对齐，修复 taskId/nodeId 回退为业务编号

### DIFF
--- a/docs/gold-band/observability-bus-design.md
+++ b/docs/gold-band/observability-bus-design.md
@@ -756,3 +756,65 @@ Bus:   orchestrator → bus.emit(event)
 | 结构体数量 | 5 个 | 2 个（`WorkflowEvent` + `NodeMetricItem`） |
 | 测试性 | callback 耦合 `AppHandle` | subscriber 依赖 `WorkflowEvent` + `AppHandle`（不变） |
 | 净代码量 | — | **-34 行** |
+
+---
+
+
+---
+
+## 4. 补充：UUID 字段对齐与哨兵策略澄清（2026-06-29）
+
+### 4.1 问题
+
+指标统计实践中发现的数据缺陷，根因来自「隐藏 UUID 字段」在设计覆盖上的遗漏：
+
+| 现象 | 根因 |
+|---|---|
+| `taskId` 上报为 `task-001` 等业务编号 | `TaskState::new()` 不生成 uuid；旧 task.json 无 uuid 字段，上报层回退到业务 ID |
+| AI-DYNAMIC 子节点 `nodeId` 为 `bootstrap`/`morning-class` 等 slug | `DynamicNodeState` 结构本身缺少 `uuid` 字段，`emit_dynamic_worker_completed` 硬编码 `node_uuid: None`，回退到业务 slug |
+
+注：方案节点（外层 AiDynamic 节点）`NodeStarted` 行的 token 为 0 是正确语义——节点刚开始时尚未产生 token，并非缺陷。
+
+### 4.2 数据结构修复
+
+**`DynamicNodeState`（src/dynamic.rs）新增 `uuid` 字段**：
+
+```rust
+#[serde(default)]
+pub uuid: Option<String>,
+```
+
+所有 `DynamicNodeState` 生产构造点（bootstrap / 动态 worker / merge / acceptance）统一赋值 `uuid: Some(generate_uuid())`；测试 helper 赋 `None` 以保持确定性。`emit_dynamic_worker_completed` 的 `node_uuid` 由硬编码 `None` 改为 `node.uuid.clone()`。
+
+**`TaskState::new()`（src/runtime/mod.rs）从源头生成 uuid**：
+
+```rust
+impl TaskState {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            // ...
+            uuid: Some(Uuid::new_v4().simple().to_string()),
+        }
+    }
+}
+```
+
+`runtime` 为底层模块，不能反向依赖 `app::ids::generate_uuid`，故直接在 runtime 内使用 `uuid` crate（与 `app::ids::generate_uuid` 保持 `simple()` 格式一致）。新创建的 task 不再产生 `task-001` 兜底；旧 task.json 仍由 `#[serde(default)]` 容错为 `None`。
+
+### 4.3 哨兵策略澄清（一个 AUTO 流程只有一对开始/结束）
+
+**设计原则**：一个 AUTO 流程（即一个 AiDynamic 节点及其内部所有子节点）整体只产生**一对**「开始/结束」哨兵行，由外层 AiDynamic 节点唯一负责。内部子节点（bootstrap / worker / merge / acceptance）**不各自**上报开始/结束哨兵。
+
+实现机制（原有设计，本次未改动该部分）：
+
+- **外层 AiDynamic 节点**的 `NodeStarted`：其 `predecessor` 为 None（或为上一个工作流节点），走正常的开始哨兵 / 前序节点逻辑。
+- **外层 AiDynamic 节点**的 `NodeCompleted`：`suppress_sentinel = false`，产出「结束」哨兵。
+- **内部子节点**的 `NodeCompleted`：`suppress_sentinel = true`，只产出该节点自身的一条完成态业务记录（SUCCESS/FAILED，携带 token），**不**产出「结束」哨兵。
+- **内部子节点不发布 `NodeStarted` 事件**，因此**不**产出 RUNNING 行，也**不**产出「开始」哨兵。
+
+结果：一个 AUTO 流程的指标数据形态为——1 条开始哨兵 + 1 条外层节点 RUNNING + 外层节点完成态 + 各子节点完成态（每子节点 1 条）+ 1 条结束哨兵。子节点各自只有一条完成态记录，不会因为节点数量增加而放大开始/结束哨兵。
+
+### 4.4 不做的事
+
+- 不迁移旧数据（符合开发阶段破坏式更新原则），`#[serde(default)]` 仅用于避免读取旧文件崩溃。
+- 不给 AI-DYNAMIC 子节点发布 `NodeStarted`（曾尝试引入，会破坏上述哨兵策略，已回退）。

--- a/docs/gold-band/开发计划/新增流程/客户端指标统计需求.md
+++ b/docs/gold-band/开发计划/新增流程/客户端指标统计需求.md
@@ -189,3 +189,23 @@ configs/channels 下每个渠道 JSON 新增以下 4 个字段：
 - **节点指标**：orchestrator 在 node_started 时发送（前序+当前），在 node_completed 时更新 RunState.last_executed_node
 - **前序节点追踪**：通过 RunState.last_executed_node 跨 Round 追踪
 - **UUID**：Option<String> + #[serde(default)]，旧数据不迁移
+
+
+
+
+### 实现记录（2026-06-29）：UUID 字段对齐
+
+**背景**：指标统计实践中发现 `taskId` 回退为业务编号（`task-001`）、AI-DYNAMIC 子节点 `nodeId` 为 slug（`bootstrap`）等缺陷。详见 `docs/gold-band/observability-bus-design.md` 第 4 节。
+
+**变更清单**：
+
+| 文件 | 变更 |
+|---|---|
+| `src/dynamic.rs` | `DynamicNodeState` 新增 `#[serde(default)] uuid: Option<String>` |
+| `src/runtime/mod.rs` | `TaskState::new()` 从源头生成 uuid；+`use uuid::Uuid` |
+| `src/app/orchestrator.rs` | 4 个 DynamicNodeState 生产构造点补 `uuid: Some(generate_uuid())`；`emit_dynamic_worker_completed` 携带 `node_uuid` |
+| `src/dynamic.rs` / `src/runtime/mod.rs` | 新增单元测试固化 uuid 生成与 serde 兼容 |
+
+**哨兵策略（澄清，未改动）**：一个 AUTO 流程整体只有一对「开始/结束」哨兵，由外层 AiDynamic 节点负责；内部子节点只产出自身完成态一条业务记录，不发布 `NodeStarted`、不产出哨兵，避免随节点数放大。
+
+**验证**：`cargo check`（lib + bin）通过；lib 测试 201 项全过（含新增 uuid 相关测试）。

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3453,6 +3453,7 @@ mod tests {
             child_run_id: None,
             started_at: Some("2026-06-16T00:00:00Z".to_string()),
             finished_at: None,
+            uuid: None,
         }
     }
 

--- a/src/app/orchestrator.rs
+++ b/src/app/orchestrator.rs
@@ -3521,6 +3521,7 @@ fn load_or_create_dynamic_graph(ctx: &DynamicExecutionContext<'_>) -> Result<Dyn
         child_run_id: None,
         started_at: None,
         finished_at: None,
+        uuid: Some(generate_uuid()),
     };
     let run = DynamicRunState {
         version: VERSION.to_string(),
@@ -4165,7 +4166,7 @@ fn emit_dynamic_worker_completed(
             round_id: ctx.round_id.to_string(),
             round_uuid: ctx.round_uuid.map(|s| s.to_string()),
             node_id: node.id.clone(),
-            node_uuid: None,
+            node_uuid: node.uuid.clone(),
             attempt_id: dynamic_attempt_id(node),
             repo_root: app.paths.repo_root.to_string(),
             seq: None,
@@ -6757,6 +6758,7 @@ fn dynamic_node_state_from_spec(
         child_run_id: None,
         started_at: None,
         finished_at: None,
+        uuid: Some(generate_uuid()),
     };
     validate_dynamic_node_state(&node)?;
     Ok(node)
@@ -7093,6 +7095,7 @@ fn create_dynamic_merge_node(
         child_run_id: None,
         started_at: None,
         finished_at: None,
+        uuid: Some(generate_uuid()),
     };
     validate_dynamic_node_state(&node)?;
     Ok(node)
@@ -7156,6 +7159,7 @@ fn create_dynamic_acceptance_node(
         child_run_id: None,
         started_at: None,
         finished_at: None,
+        uuid: Some(generate_uuid()),
     };
     validate_dynamic_node_state(&node)?;
     Ok(node)
@@ -9816,6 +9820,7 @@ mod tests {
             child_run_id: None,
             started_at: None,
             finished_at: None,
+            uuid: None,
         }
     }
 

--- a/src/dynamic.rs
+++ b/src/dynamic.rs
@@ -129,6 +129,9 @@ pub struct DynamicNodeState {
     pub child_run_id: Option<String>,
     pub started_at: Option<String>,
     pub finished_at: Option<String>,
+    /// Hidden UUID used for metrics reporting (see docs/gold-band/observability-bus-design.md).
+    #[serde(default)]
+    pub uuid: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -738,4 +741,54 @@ pub fn validate_dynamic_group_state(state: &DynamicGroupState) -> Result<()> {
         "dynamic group must have root nodes"
     );
     Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A DynamicNodeState without the `uuid` field (legacy on-disk data)
+    /// must still deserialize thanks to `#[serde(default)]`.
+    #[test]
+    fn dynamic_node_state_uuid_is_optional_for_legacy_data() {
+        let json = r#"{
+            "version": "1",
+            "id": "bootstrap",
+            "dynamicRunId": "dr-1",
+            "kind": "worker",
+            "title": "t",
+            "task": "t",
+            "status": "ready",
+            "chainId": "bootstrap",
+            "depth": 0,
+            "dependsOn": [],
+            "workspace": { "mode": "readonly" },
+            "sessionMode": "new"
+        }"#;
+        let node: DynamicNodeState = serde_json::from_str(json).expect("legacy node must deserialize");
+        assert!(node.uuid.is_none());
+    }
+
+    /// When present, the uuid field round-trips through serde.
+    #[test]
+    fn dynamic_node_state_uuid_round_trips() {
+        let json = r#"{
+            "version": "1",
+            "id": "bootstrap",
+            "dynamicRunId": "dr-1",
+            "kind": "worker",
+            "title": "t",
+            "task": "t",
+            "status": "ready",
+            "chainId": "bootstrap",
+            "depth": 0,
+            "dependsOn": [],
+            "workspace": { "mode": "readonly" },
+            "sessionMode": "new",
+            "uuid": "abc123"
+        }"#;
+        let node: DynamicNodeState = serde_json::from_str(json).expect("node must deserialize");
+        assert_eq!(node.uuid.as_deref(), Some("abc123"));
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,6 +4,7 @@ use crate::domain::{
 };
 use anyhow::{Result, ensure};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -123,7 +124,7 @@ impl TaskState {
             id: id.into(),
             title: None,
             description: None,
-            uuid: None,
+            uuid: Some(Uuid::new_v4().simple().to_string()),
         }
     }
 }
@@ -208,4 +209,25 @@ pub fn validate_worker_ref_state(state: &WorkerRefState) -> Result<()> {
         "worker-ref provider cannot be empty"
     );
     Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_state_new_generates_uuid() {
+        let task = TaskState::new("task-001");
+        let uuid = task.uuid.expect("TaskState::new must generate a uuid");
+        assert_eq!(uuid.len(), 32);
+        assert!(uuid.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn task_state_uuid_is_unique_per_construction() {
+        let a = TaskState::new("task-a");
+        let b = TaskState::new("task-b");
+        assert_ne!(a.uuid, b.uuid);
+    }
 }


### PR DESCRIPTION
指标上报实践中 taskId 回退为 task-001、AI-DYNAMIC 子节点 nodeId 回退 为 bootstrap 等 slug，根因是隐藏 UUID 字段在设计覆盖上的遗漏：

- DynamicNodeState 缺少 uuid 字段，emit_dynamic_worker_completed 硬编码 node_uuid: None，导致回退到业务 slug
- TaskState::new() 不生成 uuid，旧 task.json 无 uuid 时回退到 task-001

修复：
- DynamicNodeState 新增 #[serde(default)] uuid 字段，4 个生产构造点 统一赋 Some(generate_uuid())，emit_dynamic_worker_completed 携带真实 uuid
- TaskState::new() 从源头生成 uuid（runtime 直接用 uuid crate，不反向 依赖 app::ids）

哨兵策略（澄清，未改动）：一个 AUTO 流程整体只有一对开始/结束哨兵，
由外层 AiDynamic 节点唯一负责；内部子节点不发布 NodeStarted，其
NodeCompleted 带 suppress_sentinel=true 只产自身完成态一条记录。

新增单元测试固化 uuid 生成与 serde 向后兼容；两份设计文档同步更新。